### PR TITLE
Add CI, linting, changelog, and auto-release workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,40 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - CHANGELOG.md
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from CHANGELOG
+        id: version
+        run: |
+          VERSION=$(grep -Eo '## \[(.+?)\] -' CHANGELOG.md | head -n 1 | awk -F'[][]' '{print $2}')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        id: check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,38 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2
+
+      - name: Check go mod tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.26"]
-
+        go-version: ["1.25", "1.26"]
     steps:
       - uses: actions/checkout@v4
 
@@ -23,13 +44,19 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: Vet
-        run: go vet ./...
-
       - name: Test
         run: go test -race -count=1 ./...
 
-      - name: Verify generated docs are up to date
+  codegen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Verify generated code is up to date
         run: |
           go generate ./...
-          git diff --exit-code docs/
+          git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2
+          version: v2.9
 
       - name: Check go mod tidy
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,27 @@ jobs:
         run: |
           go generate ./...
           git diff --exit-code
+
+      - name: Validate docs assets
+        run: |
+          # checks.json must be valid JSON
+          jq empty docs/checks.json
+
+          # Every check in the manifest must have a matching markdown file
+          for id in $(jq -r '.checks[].id' docs/checks.json); do
+            if [ ! -f "docs/checks/${id}.md" ]; then
+              echo "::error::Missing docs/checks/${id}.md for check '${id}'"
+              exit 1
+            fi
+          done
+
+          # Required page assets must exist
+          for f in docs/index.html docs/logo.png docs/checks.json; do
+            if [ ! -f "$f" ]; then
+              echo "::error::Missing required asset: $f"
+              exit 1
+            fi
+          done
+
+          count=$(jq '.checks | length' docs/checks.json)
+          echo "✓ docs/ validated: ${count} checks, all assets present"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - uses: goreleaser/goreleaser-action@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binaries
-pgdoctor
+/pgdoctor
 *.exe
 
 # IDE

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,100 @@
+version: "2"
+
+linters:
+  enable:
+    - bodyclose
+    - dogsled
+    - durationcheck
+    - forbidigo
+    - goconst
+    - godot
+    - gosec
+    - misspell
+    - paralleltest
+    - revive
+    - whitespace
+    - fatcontext
+
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: ^print(ln)?$
+        - pattern: ^fmt\.Print.*$
+          msg: Use fmt.Fprintf with the appropriate writer
+        - pattern: ^log\.Print.*$
+          msg: Use structured logging instead
+    gosec:
+      excludes:
+        - G104
+        - G301
+        - G304
+        - G306
+        - G307
+    revive:
+      rules:
+        - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: call-to-gc
+        - name: comment-spacings
+        - name: confusing-naming
+        - name: confusing-results
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: deep-exit
+        - name: defer
+        - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
+        - name: empty-block
+        - name: empty-lines
+        - name: enforce-map-style
+          arguments:
+            - literal
+        - name: enforce-slice-style
+          arguments:
+            - literal
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: if-return
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: import-shadowing
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: var-declaration
+        - name: var-naming
+    staticcheck:
+      checks:
+        - -S1016
+        - all
+
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - staticcheck
+        text: 'SA1019: '
+        source: '//nolint:deprecation '
+      # CLI output — errors writing to stdout/stderr are not actionable.
+      - linters:
+          - errcheck
+        source: 'fmt\.Fprint'
+      # Deferred Close calls — errors are not actionable.
+      - linters:
+          - errcheck
+        source: 'defer .+\.Close'
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-03-10
+
+### Added
+
+- Initial open-source release of pgdoctor.
+- 26 PostgreSQL health checks covering configuration, indexes, schema, vacuum, and performance.
+- CLI with text and JSON output formats.
+- Preset system (`all` and `triage`) for check filtering.
+- Shell completion for bash, zsh, fish, and powershell.
+- Configurable timeout thresholds for session-settings check.
+- Dynamic role discovery for session-settings check.

--- a/check/check.go
+++ b/check/check.go
@@ -80,8 +80,8 @@ type Report struct {
 func NewReport(metadata Metadata) *Report {
 	return &Report{
 		Metadata: metadata,
-		Severity:      SeverityOK, // Start at OK, will be updated as results are added
-		Results:       []Finding{},
+		Severity: SeverityOK, // Start at OK, will be updated as results are added
+		Results:  []Finding{},
 	}
 }
 

--- a/checks/cacheefficiency/check_test.go
+++ b/checks/cacheefficiency/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/cacheefficiency"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 type mockCacheEfficiencyQueryer struct {

--- a/checks/connectionefficiency/check.go
+++ b/checks/connectionefficiency/check.go
@@ -6,9 +6,9 @@ import (
 	_ "embed"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 //go:embed query.sql

--- a/checks/connectionefficiency/check_test.go
+++ b/checks/connectionefficiency/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/connectionefficiency"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 // mockQueries implements ConnectionEfficiencyQueries for testing.

--- a/checks/connectionhealth/check_test.go
+++ b/checks/connectionhealth/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/connectionhealth"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 // mockQueries implements ConnectionHealthQueries for testing.

--- a/checks/duplicateindexes/check_test.go
+++ b/checks/duplicateindexes/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/duplicateindexes"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/checks/freezeage/check_test.go
+++ b/checks/freezeage/check_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/freezeage"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/checks/indexbloat/check_test.go
+++ b/checks/indexbloat/check_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/indexbloat"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockQueryer struct {

--- a/checks/indexusage/check_test.go
+++ b/checks/indexusage/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/indexusage"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/checks/invalidindexes/check_test.go
+++ b/checks/invalidindexes/check_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/invalidindexes"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/stretchr/testify/require"
 )
 
 // Mock queryer for testing.

--- a/checks/partitioning/check_test.go
+++ b/checks/partitioning/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/partitioning"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 // Mock queryer for testing.

--- a/checks/partitionusage/check_test.go
+++ b/checks/partitionusage/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/partitionusage"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 // Finding IDs.

--- a/checks/pgversion/check_test.go
+++ b/checks/pgversion/check_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/pgversion"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/stretchr/testify/require"
 )
 
 func newStaticVersioner(row db.PGVersionRow) pgversion.VersionQueries {

--- a/checks/pktypes/check_test.go
+++ b/checks/pktypes/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/emancu/pgdoctor/check"
+	"github.com/emancu/pgdoctor/db"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/emancu/pgdoctor/check"
-	"github.com/emancu/pgdoctor/db"
 )
 
 type mockQueryer struct {

--- a/checks/replicationlag/check_test.go
+++ b/checks/replicationlag/check_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/replicationlag"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/checks/replicationslots/check_test.go
+++ b/checks/replicationslots/check_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/replicationslots"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockQueryer implements ReplicationSlotsQueries for testing.

--- a/checks/sequencehealth/check_test.go
+++ b/checks/sequencehealth/check_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/sequencehealth"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/checks/sessionsettings/check.go
+++ b/checks/sessionsettings/check.go
@@ -114,12 +114,12 @@ func (c *checker) Check(ctx context.Context) (*check.Report, error) {
 	for _, role := range roles {
 		if !dbSettings.hasRole(role) {
 			checks = append(checks, settingCheck{
-				Role:     role,
+				Role:      role,
 				Parameter: "(all)",
-				Current:  "N/A",
-				Expected: "Role exists",
-				Status:   "Role not found",
-				Severity: check.SeverityWarn,
+				Current:   "N/A",
+				Expected:  "Role exists",
+				Status:    "Role not found",
+				Severity:  check.SeverityWarn,
 			})
 			continue
 		}

--- a/checks/sessionsettings/check_test.go
+++ b/checks/sessionsettings/check_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/sessionsettings"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 func newStaticSessionSettingsQueryer(rows []db.SessionSettingsRow) sessionSettingsQueryer {
@@ -592,9 +592,9 @@ func Test_SessionSettings_ConfigOverridesDiscovery(t *testing.T) {
 			"log_min_duration_statement":          "2000",
 		},
 		"worker_user": {
-			"statement_timeout":                   "0", // bad
-			"idle_in_transaction_session_timeout": "0", // bad
-			"transaction_timeout":                 "0", // bad
+			"statement_timeout":                   "0",  // bad
+			"idle_in_transaction_session_timeout": "0",  // bad
+			"transaction_timeout":                 "0",  // bad
 			"log_min_duration_statement":          "-1", // bad
 		},
 	}

--- a/checks/statisticsfreshness/check_test.go
+++ b/checks/statisticsfreshness/check_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/statisticsfreshness"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 type mockStatisticsFreshnessQueryer struct {

--- a/checks/tablebloat/check_test.go
+++ b/checks/tablebloat/check_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/tablebloat"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockQueryer struct {

--- a/checks/tableseqscans/check_test.go
+++ b/checks/tableseqscans/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/tableseqscans"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/checks/tablevacuumhealth/check.go
+++ b/checks/tablevacuumhealth/check.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 //go:embed query.sql

--- a/checks/tablevacuumhealth/check_test.go
+++ b/checks/tablevacuumhealth/check_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/tablevacuumhealth"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/checks/tempusage/check_test.go
+++ b/checks/tempusage/check_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/tempusage"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockQueryer struct {

--- a/checks/toaststorage/check_test.go
+++ b/checks/toaststorage/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/toaststorage"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/checks/uuiddefaults/check_test.go
+++ b/checks/uuiddefaults/check_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/uuiddefaults"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 type mockQueryer struct {

--- a/checks/uuidtypes/check_test.go
+++ b/checks/uuidtypes/check_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/uuidtypes"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/stretchr/testify/require"
 )
 
 type mockQueryer struct {

--- a/checks/vacuumsettings/check_test.go
+++ b/checks/vacuumsettings/check_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/stretchr/testify/require"
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/vacuumsettings"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
 )
 
 type mockVacuumSettingsQueries struct {

--- a/cmd/pgdoctor/main.go
+++ b/cmd/pgdoctor/main.go
@@ -1,0 +1,30 @@
+// Package main is the entry point for the pgdoctor CLI.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime/debug"
+
+	"github.com/emancu/pgdoctor/internal/cli"
+)
+
+func main() {
+	if err := cli.Execute(buildVersion()); err != nil {
+		var silent *cli.SilentError
+		if errors.As(err, &silent) {
+			os.Exit(silent.ExitCode)
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func buildVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return "dev"
+	}
+	return info.Main.Version
+}

--- a/docs/checks/session-settings.md
+++ b/docs/checks/session-settings.md
@@ -80,16 +80,26 @@ WHERE r.rolcanlogin = true
 
 ## Library Configuration
 
-When using pgdoctor as a library, you can specify exact roles to check via configuration:
+When using pgdoctor as a library, you can configure roles and timeout thresholds:
 
 ```go
 cfg := check.Config{
-    "session-settings": {"roles": "app_ro,app_rw"},
+    "session-settings": {
+        "roles":        "app_ro,app_rw",
+        "timeout_warn": "2000",   // above this → WARN (default: 5000)
+        "timeout_fail": "5000",   // above this → FAIL (default: 10000)
+    },
 }
 reports, err := pgdoctor.Run(ctx, conn, pgdoctor.AllChecks(), cfg, nil, nil)
 ```
 
-When no config is provided, roles are discovered dynamically from the database.
+| Key | Description | Default |
+|-----|-------------|---------|
+| `roles` | Comma-separated list of roles to check | Discovered dynamically |
+| `timeout_warn` | Threshold (ms) above which `statement_timeout` and `transaction_timeout` produce a WARN | `5000` |
+| `timeout_fail` | Threshold (ms) above which `statement_timeout` and `transaction_timeout` produce a FAIL | `10000` |
+
+When no config is provided, roles are discovered dynamically and default thresholds apply.
 
 ## References
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/emancu/pgdoctor
 
-go 1.26.0
+go 1.25.0
 
 require (
 	github.com/charmbracelet/glamour v0.10.0

--- a/internal/cli/json.go
+++ b/internal/cli/json.go
@@ -1,3 +1,4 @@
+// Package cli implements the pgdoctor command-line interface.
 package cli
 
 import (
@@ -25,8 +26,8 @@ type jsonFinding struct {
 }
 
 type jsonTable struct {
-	Headers []string     `json:"headers"`
-	Rows    []jsonRow    `json:"rows"`
+	Headers []string  `json:"headers"`
+	Rows    []jsonRow `json:"rows"`
 }
 
 type jsonRow struct {

--- a/pgdoctor.go
+++ b/pgdoctor.go
@@ -66,9 +66,7 @@ func Run(ctx context.Context, conn db.DBTX, checks []check.Package, cfg check.Co
 //   - "category" -> "category" (exact match)
 //
 // Invalid filters are those that don't match any check ID or category.
-func ValidateFilters(checks []check.Package, filters []string) ([]string, []string) {
-	var valid, invalid []string
-
+func ValidateFilters(checks []check.Package, filters []string) (valid, invalid []string) {
 	// Build set of valid check IDs and categories
 	validCheckIDs := map[string]struct{}{}
 	validCategories := map[string]struct{}{}


### PR DESCRIPTION
## Summary

- **CI workflow**: 3 parallel jobs — lint (golangci-lint v2), test (Go 1.25 + 1.26 matrix), codegen verification
- **Linter config**: golangci-lint adapted from houston — revive, gosec, misspell, godot, paralleltest, etc.
- **Auto-tag workflow**: extracts version from CHANGELOG.md on master push → creates git tag → triggers goreleaser release
- **CHANGELOG.md**: keep-a-changelog format, initial v0.1.0 release
- **Go 1.25 minimum**: backward compatibility with previous Go version
- Fixed all lint issues across the codebase (import ordering, package comments, named returns, formatting)

## Release flow

```
PR merged → CHANGELOG.md has new [x.y.z] → auto-tag.yml creates vx.y.z tag → release.yml runs goreleaser → GitHub release with binaries
```

## Test plan

- [x] CI runs all 3 jobs (lint, test, codegen) successfully
- [ ] After merge, auto-tag creates `v0.1.0` tag
- [ ] Tag triggers release workflow and publishes binaries