### PR TITLE
fix: resilient check execution + streaming output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,8 @@ Access metadata via promoted fields:
 The public API in `pgdoctor.go` accepts an explicit check list, enabling consumers to inject custom checks:
 
 ```go
-// Run checks against a database connection
-pgdoctor.Run(ctx, conn, checks, cfg, only, ignored) ([]*check.Report, error)
+// Run checks with the given options
+pgdoctor.Run(ctx, conn, pgdoctor.Options{...})
 
 // Get all built-in checks
 pgdoctor.AllChecks() []check.Package
@@ -287,11 +287,12 @@ Five categories:
 
 ### Severity
 
+- `check.SeveritySkip` - Check could not run (timeout, permission error)
 - `check.SeverityOK` - Check passed, no action needed
 - `check.SeverityWarn` - Issue found, non-urgent action
 - `check.SeverityFail` - Issue found, urgent action required
 
-Report severity is automatically the maximum across all findings.
+Report severity is automatically the maximum across all findings. `SeveritySkip` is ordered below `SeverityOK` so it doesn't affect severity comparisons.
 
 ## Common Tasks
 
@@ -444,9 +445,16 @@ import (
     "github.com/emancu/pgdoctor/check"
 )
 
-// Combine built-in + custom checks
+// Combine built-in + custom checks, then filter
 allChecks := append(pgdoctor.AllChecks(), myContribChecks()...)
-reports, _ := pgdoctor.Run(ctx, conn, allChecks, cfg, only, ignored)
+checks := pgdoctor.Filter(allChecks, only, ignored)
+
+var reports []*check.Report
+pgdoctor.Run(ctx, conn, pgdoctor.Options{
+    Checks:   checks,
+    Config:   cfg,
+    OnReport: pgdoctor.Collect(&reports),
+})
 ```
 
 Each contrib check creates its own sqlc queries internally, using the `check.DBTX` interface. This allows organizations to add domain-specific checks (naming conventions, internal standards) without forking.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Run health checks against a PostgreSQL database. The DSN can be passed as a posi
 | `--only` | Only run these checks or categories |
 | `--ignore` | Skip these checks or categories |
 | `--preset` | Check preset: `all` (default), `triage` |
-| `--detail` | Detail level: `summary`, `brief`, `verbose`, `debug` |
+| `--detail` | Detail level: `summary`, `brief` (default), `verbose`, `debug` |
 | `--output` | Output format: `text` (default), `json` |
 | `--hide-passing` | Hide passing checks |
 
@@ -163,22 +163,22 @@ func main() {
     conn, _ := pgx.Connect(ctx, "postgres://localhost:5432/mydb")
     defer conn.Close(ctx)
 
-    reports, err := pgdoctor.Run(ctx, conn, pgdoctor.AllChecks(), nil, nil, nil)
-    if err != nil {
-        panic(err)
-    }
-
-    for _, report := range reports {
-        fmt.Printf("[%s] %s\n", report.CheckID, report.Name)
-    }
+    pgdoctor.Run(ctx, conn, pgdoctor.Options{
+        OnReport: func(report *check.Report) {
+            fmt.Printf("[%s] %s\n", report.CheckID, report.Name)
+        },
+    })
 }
 ```
 
 ### Key API
 
 ```go
-// Run checks (pass AllChecks() for built-in set, or append your own)
-pgdoctor.Run(ctx, conn, checks, cfg, only, ignored) ([]*check.Report, error)
+// Run checks with the given options
+pgdoctor.Run(ctx, conn, pgdoctor.Options{...})
+
+// Collect reports into a slice (built-in handler)
+pgdoctor.Collect(&reports) pgdoctor.ReportHandler
 
 // List all built-in checks
 pgdoctor.AllChecks() []check.Package

--- a/check/check.go
+++ b/check/check.go
@@ -3,6 +3,7 @@ package check
 
 import (
 	"context"
+	"time"
 
 	"github.com/emancu/pgdoctor/db"
 )
@@ -15,7 +16,8 @@ type DBTX = db.DBTX
 type Severity int
 
 const (
-	SeverityOK Severity = iota
+	SeveritySkip Severity = iota - 1 // Check could not run (timeout, permission error, etc.)
+	SeverityOK   Severity = iota
 	SeverityWarn
 	SeverityFail
 )
@@ -23,11 +25,13 @@ const (
 func (s Severity) String() string {
 	switch s {
 	case SeverityOK:
-		return "ok"
+		return "pass"
 	case SeverityWarn:
 		return "warn"
 	case SeverityFail:
 		return "fail"
+	case SeveritySkip:
+		return "skip"
 	default:
 		return "unknown"
 	}
@@ -74,6 +78,7 @@ type Metadata struct {
 type Report struct {
 	Metadata // Embedded, promotes CheckID, Name, Category, Description, SQL
 	Severity Severity
+	Duration time.Duration
 	Results  []Finding
 }
 

--- a/checks/sessionsettings/README.md
+++ b/checks/sessionsettings/README.md
@@ -90,7 +90,9 @@ cfg := check.Config{
         "timeout_fail": "5000",   // above this → FAIL (default: 10000)
     },
 }
-reports, err := pgdoctor.Run(ctx, conn, pgdoctor.AllChecks(), cfg, nil, nil)
+pgdoctor.Run(ctx, conn, pgdoctor.Options{
+    Config: cfg,
+})
 ```
 
 | Key | Description | Default |

--- a/checks/vacuumsettings/check.go
+++ b/checks/vacuumsettings/check.go
@@ -51,28 +51,22 @@ func (c *checker) Metadata() check.Metadata {
 func (c *checker) Check(ctx context.Context) (*check.Report, error) {
 	report := check.NewReport(Metadata())
 
-	meta := check.InstanceMetadataFromContext(ctx)
-	if meta == nil {
-		report.AddFinding(check.Finding{
-			ID:       report.CheckID,
-			Name:     report.Name,
-			Severity: check.SeverityWarn,
-			Details:  "Instance metadata not available - skipping RAM-aware vacuum settings checks",
-		})
-		return report, nil
-	}
-
 	settings, err := c.queryer.VacuumSettings(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("running %s/%s: %w", check.CategoryVacuum, report.CheckID, err)
 	}
 
 	dbSettings := dbVacuumSettings(settings)
+	meta := check.InstanceMetadataFromContext(ctx)
 
+	// These checks work without instance metadata
 	checkAutovacuumScaleFactors(dbSettings, report)
+	checkVacuumCostSettings(dbSettings, report)
+
+	// These checks degrade gracefully: critical misconfigs are always caught,
+	// but RAM-aware recommendations require instance metadata.
 	checkAutovacuumWorkers(dbSettings, report, meta)
 	checkMaintenanceWorkMem(dbSettings, report, meta)
-	checkVacuumCostSettings(dbSettings, report)
 	checkWorkMem(dbSettings, report, meta)
 
 	if len(report.Results) == 0 {
@@ -170,9 +164,8 @@ func checkAutovacuumWorkers(s dbVacuumSettings, report *check.Report, meta *chec
 		return
 	}
 
-	// Context-aware check for very large instances only
-	// Only flag when workers = 3 might genuinely be a bottleneck (≥32 vCPU)
-	if meta.VCPUCores >= 32 && workers == 3 {
+	// Context-aware check for very large instances only (requires metadata)
+	if meta != nil && meta.VCPUCores >= 32 && workers == 3 {
 		recommended := 6 // Conservative: fixed recommendation for very large instances
 
 		report.AddFinding(check.Finding{
@@ -217,8 +210,12 @@ func checkMaintenanceWorkMem(s dbVacuumSettings, report *check.Report, meta *che
 		return
 	}
 
-	// RAM-aware check: Total budget calculation
-	// CRITICAL: maintenance_work_mem × autovacuum_max_workers = total RAM used
+	// RAM-aware checks require instance metadata
+	if meta == nil {
+		return
+	}
+
+	// Total budget calculation: maintenance_work_mem × autovacuum_max_workers = total RAM used
 	availableRAMMB := int64(meta.MemoryGB * 1024)
 	totalBudgetMB := maintenanceMemMB * autovacuumMaxWorkers
 	budgetPercent := (float64(totalBudgetMB) / float64(availableRAMMB)) * 100
@@ -326,6 +323,11 @@ func checkWorkMem(s dbVacuumSettings, report *check.Report, meta *check.Instance
 				"Will cause excessive temporary file usage for sorts and hash operations.",
 				workMemMB),
 		})
+		return
+	}
+
+	// RAM-aware checks require instance metadata
+	if meta == nil {
 		return
 	}
 

--- a/docs/checks/session-settings.md
+++ b/docs/checks/session-settings.md
@@ -80,16 +80,28 @@ WHERE r.rolcanlogin = true
 
 ## Library Configuration
 
-When using pgdoctor as a library, you can specify exact roles to check via configuration:
+When using pgdoctor as a library, you can configure roles and timeout thresholds:
 
 ```go
 cfg := check.Config{
-    "session-settings": {"roles": "app_ro,app_rw"},
+    "session-settings": {
+        "roles":        "app_ro,app_rw",
+        "timeout_warn": "2000",   // above this → WARN (default: 5000)
+        "timeout_fail": "5000",   // above this → FAIL (default: 10000)
+    },
 }
-reports, err := pgdoctor.Run(ctx, conn, pgdoctor.AllChecks(), cfg, nil, nil)
+pgdoctor.Run(ctx, conn, pgdoctor.Options{
+    Config: cfg,
+})
 ```
 
-When no config is provided, roles are discovered dynamically from the database.
+| Key | Description | Default |
+|-----|-------------|---------|
+| `roles` | Comma-separated list of roles to check | Discovered dynamically |
+| `timeout_warn` | Threshold (ms) above which `statement_timeout` and `transaction_timeout` produce a WARN | `5000` |
+| `timeout_fail` | Threshold (ms) above which `statement_timeout` and `transaction_timeout` produce a FAIL | `10000` |
+
+When no config is provided, roles are discovered dynamically and default thresholds apply.
 
 ## References
 

--- a/internal/cli/json.go
+++ b/internal/cli/json.go
@@ -42,7 +42,7 @@ func formatJSON(w io.Writer, reports []*check.Report) error {
 			CheckID:  report.CheckID,
 			Name:     report.Name,
 			Category: string(report.Category),
-			Severity: severityString(report.Severity),
+			Severity: report.Severity.String(),
 			Results:  make([]jsonFinding, 0, len(report.Results)),
 		}
 
@@ -50,7 +50,7 @@ func formatJSON(w io.Writer, reports []*check.Report) error {
 			jf := jsonFinding{
 				ID:       result.ID,
 				Name:     result.Name,
-				Severity: severityString(result.Severity),
+				Severity: result.Severity.String(),
 				Details:  result.Details,
 			}
 
@@ -62,7 +62,7 @@ func formatJSON(w io.Writer, reports []*check.Report) error {
 				for _, row := range result.Table.Rows {
 					jt.Rows = append(jt.Rows, jsonRow{
 						Cells:    row.Cells,
-						Severity: severityString(row.Severity),
+						Severity: row.Severity.String(),
 					})
 				}
 				jf.Table = jt
@@ -81,17 +81,4 @@ func formatJSON(w io.Writer, reports []*check.Report) error {
 	}
 
 	return nil
-}
-
-func severityString(s check.Severity) string {
-	switch s {
-	case check.SeverityOK:
-		return "pass"
-	case check.SeverityWarn:
-		return "warn"
-	case check.SeverityFail:
-		return "fail"
-	default:
-		return "unknown"
-	}
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -5,94 +5,36 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 
 	"github.com/emancu/pgdoctor/check"
 )
 
-func formatReport(w io.Writer, reports []*check.Report, opts *runOptions, dbLabel string) check.Severity {
-	fmt.Fprintf(w, "Database Health Check: %s\n\n", dbLabel)
-
-	grouped := groupByCategory(reports)
-	maxSeverity := check.SeverityOK
-
-	for _, category := range sortedCategories(grouped) {
-		categoryReports := grouped[category]
-
-		sort.Slice(categoryReports, func(i, j int) bool {
-			if categoryReports[i].Severity != categoryReports[j].Severity {
-				return categoryReports[i].Severity > categoryReports[j].Severity
-			}
-			return categoryReports[i].CheckID < categoryReports[j].CheckID
-		})
-
-		hasVisibleReports := false
-		for _, report := range categoryReports {
-			if report.Severity > maxSeverity {
-				maxSeverity = report.Severity
-			}
-			if report.Severity != check.SeverityOK || !opts.hidePassing {
-				hasVisibleReports = true
-			}
-		}
-
-		if !hasVisibleReports {
-			continue
-		}
-
-		categoryTitle := strings.ToUpper(category)
-		fmt.Fprintln(w, categoryTitle)
-		fmt.Fprintln(w, strings.Repeat("─", len(categoryTitle)))
-
-		for _, report := range categoryReports {
-			if report.Severity == check.SeverityOK && opts.hidePassing {
-				continue
-			}
-
-			if opts.detail == string(detailSummary) {
-				printCheckSummary(w, report, opts)
-			} else {
-				printCheckReport(w, report, opts)
-			}
-		}
-
-		fmt.Fprintln(w)
-	}
-
-	printSummary(w, reports)
-
-	if opts.detail == string(detailSummary) {
-		dimFunc := dimColor()
-		fmt.Fprintf(w, "%s\n", dimFunc("To see details: pgdoctor run ... --detail brief"))
-		fmt.Fprintf(w, "%s\n", dimFunc("To see how to fix: pgdoctor explain <check-id>"))
-		fmt.Fprintln(w)
-	}
-
-	return maxSeverity
-}
-
-func groupByCategory(reports []*check.Report) map[string][]*check.Report {
-	grouped := map[string][]*check.Report{}
-	for _, report := range reports {
-		category := string(report.Category)
-		grouped[category] = append(grouped[category], report)
-	}
-	return grouped
-}
-
-func sortedCategories(grouped map[string][]*check.Report) []string {
-	categories := make([]string, 0, len(grouped))
-	for category := range grouped {
-		categories = append(categories, category)
-	}
-	sort.Strings(categories)
-	return categories
+func showTiming(opts *runOptions) bool {
+	return opts.detail == string(detailVerbose) || opts.detail == string(detailDebug)
 }
 
 func printCheckSummary(w io.Writer, report *check.Report, opts *runOptions) {
 	label, colorFunc := severityDisplay(report.Severity)
 	dimFunc := dimColor()
+
+	var timingStr string
+	if showTiming(opts) {
+		timingStr = " " + dimFunc(fmt.Sprintf("[%s]", check.FormatDurationMs(float64(report.Duration.Milliseconds()))))
+	}
+
+	// For skipped checks, show the reason inline instead of pass/total count
+	if report.Severity == check.SeveritySkip && len(report.Results) > 0 {
+		fmt.Fprintf(w, "%s %s %s%s — %s\n",
+			colorFunc(fmt.Sprintf("[%s]", label)),
+			report.Name,
+			dimFunc(fmt.Sprintf("(%s)", report.CheckID)),
+			timingStr,
+			dimFunc(report.Results[0].Details))
+		return
+	}
 
 	okCount := 0
 	for _, result := range report.Results {
@@ -102,37 +44,70 @@ func printCheckSummary(w io.Writer, report *check.Report, opts *runOptions) {
 	}
 	total := len(report.Results)
 
-	fmt.Fprintf(w, "%s %s %s %s\n",
+	fmt.Fprintf(w, "%s %s %s %s%s\n",
 		colorFunc(fmt.Sprintf("[%s]", label)),
 		report.Name,
 		dimFunc(fmt.Sprintf("(%s)", report.CheckID)),
-		dimFunc(fmt.Sprintf("(%d/%d)", okCount, total)))
+		dimFunc(fmt.Sprintf("(%d/%d)", okCount, total)),
+		timingStr)
 }
 
 func printCheckReport(w io.Writer, report *check.Report, opts *runOptions) {
 	label, colorFunc := severityDisplay(report.Severity)
 	dimFunc := dimColor()
 
-	singleFindingDuplicate := len(report.Results) == 1 && report.Results[0].ID == report.CheckID
-
-	if !singleFindingDuplicate {
-		fmt.Fprintf(w, "%s %s %s\n",
-			colorFunc(fmt.Sprintf("[%s]", label)),
-			report.Name,
-			dimFunc(fmt.Sprintf("(%s)", report.CheckID)))
+	var timingStr string
+	if showTiming(opts) {
+		timingStr = " " + dimFunc(fmt.Sprintf("[%s]", check.FormatDurationMs(float64(report.Duration.Milliseconds()))))
 	}
 
-	sortedResults := make([]check.Finding, len(report.Results))
-	copy(sortedResults, report.Results)
-	sort.Slice(sortedResults, func(i, j int) bool {
-		if sortedResults[i].Severity != sortedResults[j].Severity {
-			return sortedResults[i].Severity < sortedResults[j].Severity
-		}
-		return sortedResults[i].Name < sortedResults[j].Name
-	})
+	// Skipped checks render as a single line with the reason, same as summary mode
+	if report.Severity == check.SeveritySkip && len(report.Results) > 0 {
+		fmt.Fprintf(w, "%s %s %s%s — %s\n",
+			colorFunc(fmt.Sprintf("[%s]", label)),
+			report.Name,
+			dimFunc(fmt.Sprintf("(%s)", report.CheckID)),
+			timingStr,
+			dimFunc(report.Results[0].Details))
+		return
+	}
 
-	for _, result := range sortedResults {
-		printSubcheck(w, report, result, opts)
+	singleFinding := len(report.Results) == 1 && report.Results[0].ID == report.CheckID
+
+	// For single-finding checks, fold the details into the header line
+	if singleFinding {
+		result := report.Results[0]
+		fmt.Fprintf(w, "%s %s %s%s\n",
+			colorFunc(fmt.Sprintf("[%s]", label)),
+			report.Name,
+			dimFunc(fmt.Sprintf("(%s)", report.CheckID)),
+			timingStr)
+		if result.Severity != check.SeverityOK && result.Details != "" {
+			fmt.Fprintf(w, "%s\n", indent(result.Details, 2))
+		}
+		if result.Table != nil {
+			fmt.Fprintln(w)
+			printTable(w, result.Table, 2, opts)
+		}
+	} else {
+		fmt.Fprintf(w, "%s %s %s%s\n",
+			colorFunc(fmt.Sprintf("[%s]", label)),
+			report.Name,
+			dimFunc(fmt.Sprintf("(%s)", report.CheckID)),
+			timingStr)
+
+		sortedResults := make([]check.Finding, len(report.Results))
+		copy(sortedResults, report.Results)
+		sort.Slice(sortedResults, func(i, j int) bool {
+			if sortedResults[i].Severity != sortedResults[j].Severity {
+				return sortedResults[i].Severity < sortedResults[j].Severity
+			}
+			return sortedResults[i].Name < sortedResults[j].Name
+		})
+
+		for _, result := range sortedResults {
+			printSubcheck(w, report, result, opts)
+		}
 	}
 
 	if opts.detail == string(detailDebug) && report.SQL != "" {
@@ -232,8 +207,10 @@ func printTable(w io.Writer, table *check.Table, indentSpaces int, opts *runOpti
 }
 
 func printSummary(w io.Writer, reports []*check.Report) {
-	okCount, warnCount, failCount := 0, 0, 0
+	okCount, warnCount, failCount, skipCount := 0, 0, 0, 0
+	var totalDuration time.Duration
 	for _, report := range reports {
+		totalDuration += report.Duration
 		switch report.Severity {
 		case check.SeverityOK:
 			okCount++
@@ -241,6 +218,8 @@ func printSummary(w io.Writer, reports []*check.Report) {
 			warnCount++
 		case check.SeverityFail:
 			failCount++
+		case check.SeveritySkip:
+			skipCount++
 		}
 	}
 
@@ -256,8 +235,13 @@ func printSummary(w io.Writer, reports []*check.Report) {
 	if okCount > 0 {
 		summaryParts = append(summaryParts, colorForSeverity(check.SeverityOK)(fmt.Sprintf("%d passed", okCount)))
 	}
+	if skipCount > 0 {
+		summaryParts = append(summaryParts, colorForSeverity(check.SeveritySkip)(fmt.Sprintf("%d skipped", skipCount)))
+	}
 
-	fmt.Fprintf(w, "Summary: %s\n", strings.Join(summaryParts, ", "))
+	dimFunc := dimColor()
+	fmt.Fprintf(w, "Summary: %s %s\n", strings.Join(summaryParts, ", "),
+		dimFunc(fmt.Sprintf("(%d checks in %s)", len(reports), check.FormatDurationMs(float64(totalDuration.Milliseconds())))))
 	fmt.Fprintln(w)
 }
 
@@ -288,6 +272,9 @@ func colorForSeverity(severity check.Severity) func(string) string {
 		return func(s string) string { return fn(s) }
 	case check.SeverityFail:
 		fn := color.New(color.FgRed).SprintFunc()
+		return func(s string) string { return fn(s) }
+	case check.SeveritySkip:
+		fn := color.New(color.FgMagenta).SprintFunc()
 		return func(s string) string { return fn(s) }
 	default:
 		return func(s string) string { return s }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/cobra"
@@ -68,6 +70,12 @@ the level of detail, and --hide-passing to only show failures and warnings.`,
 			}
 			defer conn.Close(ctx)
 
+			// Set statement_timeout so PostgreSQL kills individual slow queries.
+			if _, err := conn.Exec(ctx, fmt.Sprintf("SET statement_timeout = %d", pgdoctor.DefaultStatementTimeoutMs)); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to set statement_timeout: %v\n", err)
+				return &SilentError{ExitCode: 2}
+			}
+
 			allChecks := pgdoctor.AllChecks()
 
 			// Apply preset filter
@@ -80,7 +88,7 @@ the level of detail, and --hide-passing to only show failures and warnings.`,
 				}
 			}
 
-			// Validate filters
+			// Validate and apply filters
 			validOnly, invalidOnly := pgdoctor.ValidateFilters(allChecks, opts.only)
 			validIgnored, invalidIgnored := pgdoctor.ValidateFilters(allChecks, opts.ignored)
 
@@ -97,16 +105,20 @@ the level of detail, and --hide-passing to only show failures and warnings.`,
 				return &SilentError{ExitCode: 1}
 			}
 
-			reports, err := pgdoctor.Run(ctx, conn, allChecks, nil, validOnly, validIgnored)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				return &SilentError{ExitCode: 1}
+			checks := pgdoctor.Filter(allChecks, validOnly, validIgnored)
+			sortChecksByCategory(checks)
+
+			runOpts := pgdoctor.Options{
+				Checks: checks,
 			}
 
-			// Format and print output
-			w := cmd.OutOrStdout()
-
+			// JSON output: batch collect then render
 			if opts.output == "json" {
+				var reports []*check.Report
+				runOpts.OnReport = pgdoctor.Collect(&reports)
+				pgdoctor.Run(ctx, conn, runOpts)
+
+				w := cmd.OutOrStdout()
 				if err := formatJSON(w, reports); err != nil {
 					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					return &SilentError{ExitCode: 1}
@@ -114,10 +126,56 @@ the level of detail, and --hide-passing to only show failures and warnings.`,
 				return nil
 			}
 
+			// Text output: stream results with category headers
+			w := cmd.OutOrStdout()
 			dbLabel := parseDSNLabel(dsn)
-			maxSeverity := formatReport(w, reports, opts, dbLabel)
+			fmt.Fprintf(w, "Database Health Check: %s\n\n", dbLabel)
 
-			if maxSeverity > check.SeverityWarn {
+			var reports []*check.Report
+			var currentCategory string
+			maxSeverity := check.SeverityOK
+
+			runOpts.OnReport = func(r *check.Report) {
+				reports = append(reports, r)
+				if r.Severity > maxSeverity {
+					maxSeverity = r.Severity
+				}
+
+				// Print category header on transition
+				cat := string(r.Category)
+				if cat != currentCategory {
+					if currentCategory != "" {
+						fmt.Fprintln(w)
+					}
+					title := strings.ToUpper(cat)
+					fmt.Fprintln(w, title)
+					fmt.Fprintln(w, strings.Repeat("─", len(title)))
+					currentCategory = cat
+				}
+
+				if r.Severity == check.SeverityOK && opts.hidePassing {
+					return
+				}
+
+				if opts.detail == string(detailSummary) {
+					printCheckSummary(w, r, opts)
+				} else {
+					printCheckReport(w, r, opts)
+				}
+			}
+			pgdoctor.Run(ctx, conn, runOpts)
+
+			fmt.Fprintln(w)
+			printSummary(w, reports)
+
+			if opts.detail == string(detailSummary) || opts.detail == string(detailBrief) {
+				dimFunc := dimColor()
+				fmt.Fprintf(w, "%s\n", dimFunc("To see more: pgdoctor run ... --detail verbose"))
+				fmt.Fprintf(w, "%s\n", dimFunc("To see how to fix: pgdoctor explain <check-id>"))
+				fmt.Fprintln(w)
+			}
+
+			if maxSeverity == check.SeverityFail {
 				return &SilentError{ExitCode: 1}
 			}
 
@@ -128,11 +186,17 @@ the level of detail, and --hide-passing to only show failures and warnings.`,
 	cmd.Flags().StringSliceVar(&opts.ignored, "ignore", nil, "Checks or categories to ignore")
 	cmd.Flags().StringSliceVar(&opts.only, "only", nil, "Only run these checks or categories")
 	cmd.Flags().StringVar(&opts.preset, "preset", presetAll, "Check preset: all (default), triage")
-	cmd.Flags().StringVar(&opts.detail, "detail", string(detailSummary), "Detail level: summary, brief, verbose, debug")
+	cmd.Flags().StringVar(&opts.detail, "detail", string(detailBrief), "Detail level: summary, brief (default), verbose, debug")
 	cmd.Flags().BoolVar(&opts.hidePassing, "hide-passing", false, "Hide passing checks")
 	cmd.Flags().StringVar(&opts.output, "output", "text", "Output format: text (default), json")
 
 	return cmd
+}
+
+func sortChecksByCategory(checks []check.Package) {
+	sort.SliceStable(checks, func(i, j int) bool {
+		return checks[i].Metadata().Category < checks[j].Metadata().Category
+	})
 }
 
 // parseDSNLabel extracts a human-readable label from a DSN.

--- a/pgdoctor.go
+++ b/pgdoctor.go
@@ -5,56 +5,116 @@ package pgdoctor
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
-const checkTimeout = 2 * time.Second
+// DefaultStatementTimeoutMs is the PostgreSQL statement_timeout in milliseconds.
+// Callers should SET this on the connection before calling Run().
+const DefaultStatementTimeoutMs = 2000
 
-// Run is the entrypoint to executing pgdoctor's checks.
-// Returns all check reports with their metadata and results.
-// Use AllChecks() for the built-in set, or append contrib checks for custom runs.
-func Run(ctx context.Context, conn db.DBTX, checks []check.Package, cfg check.Config, only, ignored []string) ([]*check.Report, error) {
-	ignoredMap := map[string]struct{}{}
-	for _, ignore := range ignored {
-		ignoredMap[ignore] = struct{}{}
+// ReportHandler is called once per check after it completes.
+type ReportHandler func(*check.Report)
+
+// Collect returns a ReportHandler that appends each report to the given slice.
+func Collect(reports *[]*check.Report) ReportHandler {
+	return func(r *check.Report) { *reports = append(*reports, r) }
+}
+
+// Options configures a pgdoctor run.
+type Options struct {
+	Checks   []check.Package
+	Config   check.Config
+	OnReport ReportHandler
+}
+
+// Run executes checks sequentially against the given connection.
+//
+// Important: callers should SET statement_timeout on the connection before calling Run()
+// to prevent slow queries from blocking the database. See DefaultStatementTimeoutMs.
+func Run(ctx context.Context, conn db.DBTX, opts Options) {
+	onReport := opts.OnReport
+	if onReport == nil {
+		onReport = func(*check.Report) {}
 	}
-	onlyMap := map[string]struct{}{}
-	for _, o := range only {
-		onlyMap[o] = struct{}{}
-	}
 
-	var allReports []*check.Report
+	for _, pkg := range opts.Checks {
+		checker := pkg.New(conn, opts.Config)
 
-	for _, pkg := range checks {
-		// Instantiate the checker for this check
-		checker := pkg.New(conn, cfg)
-		if !shouldRunCheck(checker, onlyMap, ignoredMap) {
-			continue
-		}
-
-		// Create timeout context for this check
-		checkCtx, cancel := context.WithTimeout(ctx, checkTimeout)
-		report, err := checker.Check(checkCtx)
-		cancel() // Release resources immediately
+		start := time.Now()
+		report, err := checker.Check(ctx)
+		elapsed := time.Since(start)
 
 		if err != nil {
 			metadata := checker.Metadata()
-			if errors.Is(err, context.DeadlineExceeded) {
-				return nil, fmt.Errorf("check %s/%s timed out after %s",
-					metadata.Category, metadata.CheckID, checkTimeout)
+			report = check.NewReport(metadata)
+			report.Severity = check.SeveritySkip
+
+			detail := err.Error()
+			if isStatementTimeout(err) {
+				detail = "query cancelled by statement_timeout"
 			}
-			return nil, err
+
+			report.AddFinding(check.Finding{
+				ID:       "error",
+				Name:     "Check Error",
+				Severity: check.SeveritySkip,
+				Details:  detail,
+			})
 		}
 
-		allReports = append(allReports, report)
+		report.Duration = elapsed
+		onReport(report)
+	}
+}
+
+// Filter returns checks matching the only/ignored filters.
+// If only is non-empty, only checks matching those check IDs or categories are included.
+// Checks matching ignored check IDs or categories are excluded.
+func Filter(checks []check.Package, only, ignored []string) []check.Package {
+	if len(only) == 0 && len(ignored) == 0 {
+		return checks
 	}
 
-	return allReports, nil
+	onlyMap := toSet(only)
+	ignoredMap := toSet(ignored)
+
+	var filtered []check.Package
+	for _, pkg := range checks {
+		metadata := pkg.Metadata()
+		checkID := metadata.CheckID
+		category := string(metadata.Category)
+
+		if len(onlyMap) > 0 {
+			if _, ok := onlyMap[checkID]; !ok {
+				if _, ok := onlyMap[category]; !ok {
+					continue
+				}
+			}
+		}
+
+		if _, ok := ignoredMap[checkID]; ok {
+			continue
+		}
+		if _, ok := ignoredMap[category]; ok {
+			continue
+		}
+
+		filtered = append(filtered, pkg)
+	}
+	return filtered
+}
+
+func toSet(items []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		m[item] = struct{}{}
+	}
+	return m
 }
 
 // ValidateFilters normalizes filter strings and validates them against available checks.
@@ -139,23 +199,8 @@ func AllFilters() []string {
 	return filters
 }
 
-func shouldRunCheck(checker check.Checker, only, ignored map[string]struct{}) bool {
-	metadata := checker.Metadata()
-
-	if len(only) > 0 {
-		_, categoryInOnly := only[string(metadata.Category)]
-		_, checkIDInOnly := only[metadata.CheckID]
-		if !categoryInOnly && !checkIDInOnly {
-			return false
-		}
-	}
-
-	if _, ignoredCategory := ignored[string(metadata.Category)]; ignoredCategory {
-		return false
-	}
-	if _, ignoredCheck := ignored[metadata.CheckID]; ignoredCheck {
-		return false
-	}
-
-	return true
+// isStatementTimeout checks if the error is a PostgreSQL statement_timeout (SQLSTATE 57014).
+func isStatementTimeout(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "57014"
 }

--- a/pgdoctor_test.go
+++ b/pgdoctor_test.go
@@ -1,9 +1,15 @@
 package pgdoctor
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/emancu/pgdoctor/check"
+	"github.com/emancu/pgdoctor/db"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateFilters(t *testing.T) {
@@ -75,4 +81,80 @@ func TestValidateFilters(t *testing.T) {
 			assert.ElementsMatch(t, tt.expectedInval, invalid, "invalid filters should match")
 		})
 	}
+}
+
+// fakeChecker is a test double that implements check.Checker.
+type fakeChecker struct {
+	metadata check.Metadata
+	report   *check.Report
+	err      error
+}
+
+func (f *fakeChecker) Metadata() check.Metadata { return f.metadata }
+
+func (f *fakeChecker) Check(_ context.Context) (*check.Report, error) {
+	return f.report, f.err
+}
+
+func fakePackage(id string, category check.Category, report *check.Report, err error) check.Package {
+	meta := check.Metadata{CheckID: id, Name: id, Category: category}
+	return check.Package{
+		Metadata: func() check.Metadata { return meta },
+		New: func(_ db.DBTX, _ check.Config) check.Checker {
+			return &fakeChecker{metadata: meta, report: report, err: err}
+		},
+	}
+}
+
+func TestRun_ContinuesAfterStatementTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a PostgreSQL statement_timeout error (SQLSTATE 57014)
+	pgErr := &pgconn.PgError{Code: "57014", Message: "canceling statement due to statement timeout"}
+
+	fastReport := check.NewReport(check.Metadata{CheckID: "fast-check", Name: "Fast", Category: check.CategoryConfigs})
+	fastReport.AddFinding(check.Finding{ID: "ok", Name: "OK", Severity: check.SeverityOK, Details: "all good"})
+
+	var reports []*check.Report
+	Run(context.Background(), nil, Options{
+		Checks: []check.Package{
+			fakePackage("slow-check", check.CategoryConfigs, nil, pgErr),
+			fakePackage("fast-check", check.CategoryConfigs, fastReport, nil),
+		},
+		OnReport: Collect(&reports),
+	})
+	require.Len(t, reports, 2)
+
+	assert.Equal(t, check.SeveritySkip, reports[0].Severity)
+	assert.Equal(t, "slow-check", reports[0].CheckID)
+	require.Len(t, reports[0].Results, 1)
+	assert.Contains(t, reports[0].Results[0].Details, "statement_timeout")
+
+	assert.Equal(t, check.SeverityOK, reports[1].Severity)
+	assert.Equal(t, "fast-check", reports[1].CheckID)
+}
+
+func TestRun_ContinuesAfterCheckError(t *testing.T) {
+	t.Parallel()
+
+	goodReport := check.NewReport(check.Metadata{CheckID: "good-check", Name: "Good", Category: check.CategoryConfigs})
+	goodReport.AddFinding(check.Finding{ID: "ok", Name: "OK", Severity: check.SeverityOK})
+
+	var reports []*check.Report
+	Run(context.Background(), nil, Options{
+		Checks: []check.Package{
+			fakePackage("broken-check", check.CategoryConfigs, nil, fmt.Errorf("connection refused")),
+			fakePackage("good-check", check.CategoryConfigs, goodReport, nil),
+		},
+		OnReport: Collect(&reports),
+	})
+	require.Len(t, reports, 2)
+
+	assert.Equal(t, check.SeveritySkip, reports[0].Severity)
+	assert.Equal(t, "broken-check", reports[0].CheckID)
+	require.Len(t, reports[0].Results, 1)
+	assert.Contains(t, reports[0].Results[0].Details, "connection refused")
+
+	assert.Equal(t, check.SeverityOK, reports[1].Severity)
+	assert.Equal(t, "good-check", reports[1].CheckID)
 }


### PR DESCRIPTION
## Problem
A single check timeout or error aborted the entire pgdoctor run — no subsequent checks executed.

## Changes

**Error handling**
- Failed checks produce a `SeveritySkip` report and the run continues
- Use PostgreSQL `statement_timeout` instead of Go context timeout (per-query, connection stays healthy)

**Streaming output**
- Results print as each check completes (with category headers) instead of batching
- Per-check timing in `--detail verbose/debug`, total timing always in summary

**API redesign**
- `Run()` accepts `Options` struct + `ReportHandler` callback (no error return)
- New `Filter()` function separates check selection from execution
- New `Collect()` helper for batch consumers
- `SeverityOK.String()` returns `"pass"` (4-char alignment: pass/warn/fail/skip)
- Default detail level changed from `summary` to `brief`

**Bug fixes**
- `vacuum-settings` check no longer skips entirely without instance metadata — runs non-RAM-dependent checks

## Test plan
- [x] `TestRun_ContinuesAfterStatementTimeout`
- [x] `TestRun_ContinuesAfterCheckError`
- [x] All existing tests pass
- [x] Manual test against production RDS (~9s with streaming vs ~30s before)