### PR TITLE
fix(checks): correct session-settings, quiet idle-ratio, make replication-lag capacity-aware

### DIFF
--- a/check/format.go
+++ b/check/format.go
@@ -2,6 +2,9 @@ package check
 
 import (
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -54,6 +57,64 @@ func FormatDurationMs(ms float64) string {
 		return fmt.Sprintf("%.1fs", ms/1000)
 	}
 	return fmt.Sprintf("%.0fms", ms)
+}
+
+// timeUnitFactors maps a PostgreSQL GUC time-unit suffix to its millisecond
+// multiplier. PostgreSQL recognises only these lowercase, case-sensitive
+// suffixes; there is no bare "m" time unit ("min" is the only minute spelling).
+var timeUnitFactors = map[string]float64{
+	"us":  1.0 / 1000,
+	"ms":  1,
+	"s":   1000,
+	"min": 60000,
+	"h":   3600000,
+	"d":   86400000,
+}
+
+// ParseDurationMs parses a PostgreSQL GUC time value into integer milliseconds —
+// the inverse of FormatDurationMs. Unlike pg_settings.setting (always normalised
+// to the base unit), raw ALTER ROLE / pg_db_role_setting values are stored
+// verbatim, so they may carry a unit suffix ("2000ms", "1.5s", "2000 ms") or be a
+// bare number interpreted in baseUnit. The sign is preserved so sentinel values
+// like -1 (disabled) survive.
+func ParseDurationMs(value, baseUnit string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, fmt.Errorf("empty value")
+	}
+
+	// Match the longest trailing alphabetic suffix that is a known time unit.
+	numeric, factor := value, durationUnitFactor(baseUnit)
+	for i := len(value) - 1; i >= 0; i-- {
+		if !isASCIILetter(value[i]) {
+			suffix := value[i+1:]
+			if f, ok := timeUnitFactors[suffix]; ok {
+				numeric = strings.TrimSpace(value[:i+1])
+				factor = f
+			}
+			break
+		}
+	}
+
+	n, err := strconv.ParseFloat(numeric, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing numeric part %q: %w", numeric, err)
+	}
+
+	return int64(math.Round(n * factor)), nil
+}
+
+// durationUnitFactor returns the ms multiplier for a value's base unit,
+// defaulting to milliseconds when the unit is empty or not a known time unit.
+func durationUnitFactor(unit string) float64 {
+	if f, ok := timeUnitFactors[unit]; ok {
+		return f
+	}
+	return 1
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
 // FormatDurationSec formats seconds as a human-readable duration (e.g., "2h" or "1d").

--- a/check/format_test.go
+++ b/check/format_test.go
@@ -1,0 +1,49 @@
+package check_test
+
+import (
+	"testing"
+
+	"github.com/emancu/pgdoctor/check"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDurationMs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    string
+		baseUnit string
+		expect   int64
+	}{
+		{name: "ms suffix", value: "2000ms", expect: 2000},
+		{name: "seconds suffix", value: "2s", expect: 2000},
+		{name: "minutes suffix", value: "1min", expect: 60000},
+		{name: "bare number defaults to ms", value: "2000", expect: 2000},
+		{name: "zero", value: "0", expect: 0},
+		{name: "disabled sentinel keeps sign", value: "-1", expect: -1},
+		{name: "fractional seconds", value: "1.5s", expect: 1500},
+		{name: "space before unit", value: "2000 ms", expect: 2000},
+		{name: "bare number with ms base unit", value: "2000", baseUnit: "ms", expect: 2000},
+		{name: "microseconds round to nearest ms", value: "1500us", expect: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := check.ParseDurationMs(tt.value, tt.baseUnit)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, got)
+		})
+	}
+}
+
+func TestParseDurationMs_Invalid(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"", "  ", "abc", "12x3"} {
+		_, err := check.ParseDurationMs(value, "ms")
+		require.Error(t, err, "expected error for %q", value)
+	}
+}

--- a/checks/connectionhealth/README.md
+++ b/checks/connectionhealth/README.md
@@ -97,8 +97,9 @@ The `connection-efficiency` check shows that connections are well-utilized over 
 Detects when too many connections are idle, indicating an oversized pool.
 
 **Thresholds:**
-- Warning: >50% of connections idle (minimum 20 connections)
-- Critical: >75% of connections idle
+- Warning: ≥90% of connections idle (minimum 20 connections)
+
+Advisory only — a high idle ratio never fails the check. Real connection-exhaustion risk is covered by `connection-saturation` and `pool-pressure`.
 
 **What it means:**
 Many idle connections waste memory and connection slots. This often indicates:

--- a/checks/connectionhealth/check.go
+++ b/checks/connectionhealth/check.go
@@ -20,8 +20,9 @@ const (
 	saturationWarnPercent = 70.0
 	saturationFailPercent = 85.0
 
-	idleRatioWarnPercent = 50.0
-	idleRatioFailPercent = 75.0
+	// Idle ratio is advisory only — saturation and pool-pressure already guard
+	// real connection exhaustion, so this check can only ever be OK or WARN.
+	idleRatioWarnPercent = 90.0
 	// Skip idle ratio check below this threshold to avoid false positives
 	// in low-traffic databases.
 	minConnectionsForIdleCheck = int64(20)
@@ -232,15 +233,10 @@ func checkIdleRatio(stats db.ConnectionStatsRow, report *check.Report) {
 		return
 	}
 
-	severity := check.SeverityWarn
-	if idlePercent >= idleRatioFailPercent {
-		severity = check.SeverityFail
-	}
-
 	report.AddFinding(check.Finding{
 		ID:       "idle-ratio",
 		Name:     "Idle Connection Ratio",
-		Severity: severity,
+		Severity: check.SeverityWarn,
 		Details:  fmt.Sprintf("High idle ratio: %.1f%% of connections (%d/%d) are idle", idlePercent, idle, total),
 	})
 }

--- a/checks/connectionhealth/check_test.go
+++ b/checks/connectionhealth/check_test.go
@@ -302,22 +302,28 @@ func Test_ConnectionHealth_IdleRatio(t *testing.T) {
 			expectedSeverity: check.SeverityOK,
 		},
 		{
+			name:             "reported sample no longer fails",
+			total:            29,
+			idle:             22, // 75.9% idle - advisory, stays OK
+			expectedSeverity: check.SeverityOK,
+		},
+		{
 			name:             "healthy idle ratio",
 			total:            100,
-			idle:             40, // 40% (below 50% warn threshold)
+			idle:             40, // 40% (well below 90% warn threshold)
 			expectedSeverity: check.SeverityOK,
 		},
 		{
 			name:             "warning idle ratio",
-			total:            100,
-			idle:             60, // 60% (at or above 50% warn threshold)
+			total:            29,
+			idle:             27, // 93.1% (at or above 90% warn threshold)
 			expectedSeverity: check.SeverityWarn,
 		},
 		{
-			name:             "fail idle ratio",
+			name:             "very high idle ratio still only warns",
 			total:            100,
-			idle:             92, // 92%
-			expectedSeverity: check.SeverityFail,
+			idle:             95, // 95% - no longer a FAIL tier
+			expectedSeverity: check.SeverityWarn,
 		},
 	}
 
@@ -593,7 +599,7 @@ func Test_ConnectionHealth_TableDetails(t *testing.T) {
 
 		stats := healthyStats()
 		stats.TotalConnections = int64Val(100)
-		stats.IdleConnections = int64Val(85) // trigger warning
+		stats.IdleConnections = int64Val(92) // trigger warning (>= 90%)
 
 		mock := &mockQueries{
 			stats: stats,

--- a/checks/replicationlag/README.md
+++ b/checks/replicationlag/README.md
@@ -64,23 +64,31 @@ Physical replication uses streaming replication protocol where WAL is sent direc
 
 Monitors replay lag for logical replication subscribers (CDC, selective replication, Debezium).
 
-**Severity:**
-- FAIL: >= 35 seconds
-- WARN: >= 20 seconds
-- OK: < 20 seconds
+Severity is the **maximum of two independent tiers** evaluated per slot. A slot is flagged if either tier fires.
 
-**Why much looser than physical?** Logical replication (especially Debezium/CDC) involves:
-- Decoding WAL into logical changes
-- Publishing to external systems (e.g., Kafka)
-- Waiting for Kafka acknowledgments (with `acks=all` replication)
-- Debezium batch processing and LSN flushing (can wait up to 30 seconds)
+#### Tier A — absolute liveness (time AND bytes)
 
-**Debezium-specific behavior:** The Debezium PostgreSQL connector batches changes and flushes LSN positions back to PostgreSQL periodically. During low-activity periods, it can legitimately hold WAL positions for 10-30 seconds before acknowledging consumption. This is normal operation, not a failure.
+Requires **both** a sustained high replay lag **and** a material backlog:
 
-**Thresholds explained:**
-- **< 20s**: Normal operation, including Debezium batch processing
-- **20-35s**: Something may be slow (Kafka backpressure, consumer lag) - investigate
-- **>= 35s**: Consumer is genuinely stuck or misconfigured - requires intervention
+- WARN: replay lag >= 120s **AND** backlog >= 550 MiB
+- FAIL: replay lag >= 300s **AND** backlog >= 2 GiB
+- OK: otherwise
+
+**Why gate on both?** For Debezium/CDC, `replay_lag` time tracks the connector's LSN-ack cadence (batching, Kafka round-trips), not danger. A slot can show high time with a tiny backlog during low-activity periods — that is normal batch behaviour, not a failure. The backlog in bytes is the real risk signal. Requiring both dimensions avoids paging on routine batching while still catching a genuinely growing, stuck slot.
+
+#### Tier B — capacity-relative (backlog vs retention budget)
+
+Active **only when `max_slot_wal_keep_size` is a real cap** (a positive value). On RDS the default is `-1` (unlimited), which **disables this tier** — Tier A is then the only signal.
+
+- WARN: backlog >= 50% of `max_slot_wal_keep_size`
+- FAIL: backlog >= 85% of `max_slot_wal_keep_size`
+- OK: otherwise (or cap is `-1`/unset)
+
+This tier is **independent of time**: a backlog consuming most of the retention budget is dangerous regardless of how long the slot has been lagging.
+
+**Why an early-warning tier?** `wal_status` reflects what Postgres has *already* done to the slot: `reserved`/`extended` mean WAL is still kept, `unreserved` means the slot has exceeded its budget and its WAL is at risk of removal, `lost` means WAL is already gone. Tier B fires at 50-85% of the cap *while `wal_status` is still `reserved`/`extended`* — i.e. **before** the budget is exhausted and the status flips to `unreserved`. The 85% FAIL threshold deliberately sits below 100% to give headroom to act. At 100% the slot flips to `unreserved` and both this check (relative FAIL) and `wal-retention` (FAIL) fire as separate findings of equal severity — reinforcing, not double-counting, so page severity is unchanged.
+
+The fraction is computed in `float64` (`backlog / cap`) to avoid integer overflow at large caps.
 
 ## Lag Metrics Explained
 
@@ -115,7 +123,7 @@ For Debezium and other CDC tools using logical replication, `replay_lag` measure
 
 ### What This Means
 
-When you see "30 seconds of lag" for Debezium, this includes:
+Debezium's reported `replay_lag` time bundles several stages:
 - WAL decoding time (usually <100ms)
 - Kafka publish time (usually <1 second)
 - Kafka acknowledgment time (depends on `acks=all` and replication)
@@ -123,18 +131,21 @@ When you see "30 seconds of lag" for Debezium, this includes:
 
 ### Normal vs Problematic Lag
 
-**Normal Debezium latency:** 1-2 seconds
-- Includes WAL decode + Kafka round-trip with `acks=all`
-- Kafka typically responds in milliseconds to low seconds
+High `replay_lag` **time on its own is normal** for Debezium — it reflects the
+connector's LSN-ack cadence (batching for throughput), not danger. A slot sitting at
+tens of seconds of replay lag with a small backlog is healthy and is intentionally
+reported as OK.
 
-**Problematic lag:** 5+ seconds (your threshold)
-- Indicates actual processing backlog
-- Could be caused by:
-  - High write volume (too many changes to process)
-  - Kafka broker issues (slow responses, replication lag)
-  - Network latency (Debezium to Kafka connection)
-  - Debezium configuration (batch sizes too small)
-  - Downstream consumer lag (backpressure from slow consumers)
+Lag is **problematic** only when it signals an unbounded, growing backlog, which is
+what the `logical-replication-lag` thresholds above capture:
+- **Liveness** — replay lag time stays high *and* the retained backlog is large
+  (≥120s + ≥550 MiB → warn; ≥300s + ≥2 GiB → fail).
+- **Capacity** — the backlog consumes a large fraction of `max_slot_wal_keep_size`
+  (≥50% → warn; ≥85% → fail), when a cap is set. This is the early signal before
+  `wal_status` flips to `unreserved`.
+
+A growing backlog is usually caused by a stuck or slow consumer: Kafka broker issues,
+network problems, too-small Debezium batch sizes, or downstream backpressure.
 
 ### Diagnosing High Debezium Lag
 

--- a/checks/replicationlag/check.go
+++ b/checks/replicationlag/check.go
@@ -23,10 +23,22 @@ const (
 	physicalFailSeconds = 1.0  // 1 second
 
 	// Logical replication thresholds (CDC/Debezium, selective replication).
-	// Debezium can wait up to 30 seconds to acknowledge WAL consumption during batch processing.
-	// These thresholds accommodate Debezium's normal operation while detecting genuine issues.
-	logicalWarnSeconds = 20.0 // 20 seconds - investigation threshold
-	logicalFailSeconds = 35.0 // 35 seconds - exceeds Debezium max ack window
+	//
+	// Absolute liveness tier: replay_lag time tracks Debezium's ack cadence, not
+	// danger — the real risk is slot backlog bytes. WARN/FAIL therefore require
+	// BOTH high time AND high bytes; time alone (small backlog) is normal batch
+	// behaviour.
+	logicalWarnSeconds = 120.0             // 2 minutes
+	logicalFailSeconds = 300.0             // 5 minutes
+	logicalWarnBytes   = int64(576716800)  // 550 MiB
+	logicalFailBytes   = int64(2147483648) // 2 GiB
+
+	// Capacity-relative tier: when max_slot_wal_keep_size is a real cap (> 0), the
+	// backlog as a fraction of that budget is a danger signal independent of time.
+	// It fires before the budget is exhausted and Postgres flips wal_status to
+	// 'unreserved', giving lead time to act.
+	logicalRelativeWarnFraction = 0.50
+	logicalRelativeFailFraction = 0.85
 
 	// WAL retention status values.
 	walStatusLost       = "lost"
@@ -172,19 +184,58 @@ func checkPhysicalReplicationLag(rows []db.ReplicationLagRow, report *check.Repo
 	})
 }
 
+// logicalLagSeverity is the MAX of two independent tiers. The absolute liveness
+// tier gates on BOTH time AND bytes (high time with a small backlog is normal
+// Debezium batching). The capacity-relative tier — active only when capBytes is a
+// real cap (> 0) — compares the backlog against a fraction of max_slot_wal_keep_size
+// regardless of time, catching a slot approaching its retention budget before
+// Postgres flips wal_status to 'unreserved'.
+func logicalLagSeverity(timeSec float64, bytes, capBytes int64) check.Severity {
+	severity := logicalAbsoluteSeverity(timeSec, bytes)
+	if rel := logicalRelativeSeverity(bytes, capBytes); rel > severity {
+		severity = rel
+	}
+	return severity
+}
+
+func logicalAbsoluteSeverity(timeSec float64, bytes int64) check.Severity {
+	if timeSec >= logicalFailSeconds && bytes >= logicalFailBytes {
+		return check.SeverityFail
+	}
+	if timeSec >= logicalWarnSeconds && bytes >= logicalWarnBytes {
+		return check.SeverityWarn
+	}
+	return check.SeverityOK
+}
+
+// logicalRelativeSeverity is disabled (always OK) unless capBytes > 0; a cap of -1
+// (unlimited, the RDS default) or 0 means there is no retention budget to measure
+// against. Fractions use float64 to avoid int64 overflow at large caps.
+func logicalRelativeSeverity(bytes, capBytes int64) check.Severity {
+	if capBytes <= 0 {
+		return check.SeverityOK
+	}
+	switch {
+	case float64(bytes) >= float64(capBytes)*logicalRelativeFailFraction:
+		return check.SeverityFail
+	case float64(bytes) >= float64(capBytes)*logicalRelativeWarnFraction:
+		return check.SeverityWarn
+	default:
+		return check.SeverityOK
+	}
+}
+
 func checkLogicalReplicationLag(rows []db.ReplicationLagRow, report *check.Report) {
 	var laggingRows []db.ReplicationLagRow
 	maxSeverity := check.SeverityOK
 
 	for _, row := range rows {
 		// COALESCE in query ensures these are always valid
-		lagSeconds := row.ReplayLagSeconds.Float64
-		if lagSeconds >= logicalWarnSeconds {
+		severity := logicalLagSeverity(row.ReplayLagSeconds.Float64, row.ReplayLagBytes.Int64, row.MaxSlotWalKeepBytes.Int64)
+		if severity != check.SeverityOK {
 			laggingRows = append(laggingRows, row)
-			if lagSeconds >= logicalFailSeconds {
-				maxSeverity = check.SeverityFail
-			} else if maxSeverity != check.SeverityFail {
-				maxSeverity = check.SeverityWarn
+			if severity > maxSeverity {
+				maxSeverity = severity
 			}
 		}
 	}
@@ -202,11 +253,7 @@ func checkLogicalReplicationLag(rows []db.ReplicationLagRow, report *check.Repor
 	var tableRows []check.TableRow
 	for _, row := range laggingRows {
 		// COALESCE in query ensures these are always valid
-		lagSeconds := row.ReplayLagSeconds.Float64
-		severity := check.SeverityWarn
-		if lagSeconds >= logicalFailSeconds {
-			severity = check.SeverityFail
-		}
+		severity := logicalLagSeverity(row.ReplayLagSeconds.Float64, row.ReplayLagBytes.Int64, row.MaxSlotWalKeepBytes.Int64)
 
 		slotName := row.SlotName.String
 		if slotName == "" {
@@ -217,7 +264,7 @@ func checkLogicalReplicationLag(rows []db.ReplicationLagRow, report *check.Repor
 			Cells: []string{
 				row.ApplicationName.String,
 				row.State.String,
-				fmt.Sprintf("%.2fs", lagSeconds),
+				fmt.Sprintf("%.2fs", row.ReplayLagSeconds.Float64),
 				check.FormatBytes(row.ReplayLagBytes.Int64),
 				slotName,
 			},

--- a/checks/replicationlag/check_test.go
+++ b/checks/replicationlag/check_test.go
@@ -58,13 +58,14 @@ func healthyPhysical(appName string) db.ReplicationLagRow {
 
 func healthyLogical(appName string) db.ReplicationLagRow {
 	return db.ReplicationLagRow{
-		ApplicationName:  pgText(appName),
-		State:            pgText("streaming"),
-		ReplicationType:  pgText("logical"),
-		ReplayLagBytes:   pgInt8(10240),
-		ReplayLagSeconds: pgFloat8(1.0), // 1s - healthy for logical
-		SlotName:         pgText(fmt.Sprintf("%s_slot", appName)),
-		WalStatus:        pgText("reserved"),
+		ApplicationName:     pgText(appName),
+		State:               pgText("streaming"),
+		ReplicationType:     pgText("logical"),
+		ReplayLagBytes:      pgInt8(10240),
+		ReplayLagSeconds:    pgFloat8(1.0), // 1s - healthy for logical
+		MaxSlotWalKeepBytes: pgInt8(capUnlimited),
+		SlotName:            pgText(fmt.Sprintf("%s_slot", appName)),
+		WalStatus:           pgText("reserved"),
 	}
 }
 
@@ -80,39 +81,54 @@ func laggingPhysical(appName string, lagSeconds float64) db.ReplicationLagRow {
 	}
 }
 
-func laggingLogical(appName string, lagSeconds float64) db.ReplicationLagRow {
+// laggingLogical builds a logical row with explicit time AND bytes AND the
+// cluster's max_slot_wal_keep_size cap. Severity is the max of the absolute tier
+// (time AND bytes) and the capacity-relative tier (bytes vs cap fraction), so
+// tests must supply all three. Pass capUnlimited to disable the relative tier.
+func laggingLogical(appName string, lagSeconds float64, lagBytes, capBytes int64) db.ReplicationLagRow {
 	return db.ReplicationLagRow{
-		ApplicationName:  pgText(appName),
-		State:            pgText("streaming"),
-		ReplicationType:  pgText("logical"),
-		ReplayLagBytes:   pgInt8(int64(lagSeconds * 1024 * 1024)),
-		ReplayLagSeconds: pgFloat8(lagSeconds),
-		SlotName:         pgText(fmt.Sprintf("%s_slot", appName)),
-		WalStatus:        pgText("reserved"),
+		ApplicationName:     pgText(appName),
+		State:               pgText("streaming"),
+		ReplicationType:     pgText("logical"),
+		ReplayLagBytes:      pgInt8(lagBytes),
+		ReplayLagSeconds:    pgFloat8(lagSeconds),
+		MaxSlotWalKeepBytes: pgInt8(capBytes),
+		SlotName:            pgText(fmt.Sprintf("%s_slot", appName)),
+		WalStatus:           pgText("reserved"),
 	}
 }
 
+const (
+	gib          = int64(1024 * 1024 * 1024)
+	mib          = int64(1024 * 1024)
+	capUnlimited = int64(-1)        // max_slot_wal_keep_size = -1 (RDS default)
+	warnBytes    = int64(576716800) // logicalWarnBytes (550 MiB)
+	failBytes    = 2 * gib          // logicalFailBytes (2 GiB)
+)
+
 func nonStreamingState(appName, state string) db.ReplicationLagRow {
 	return db.ReplicationLagRow{
-		ApplicationName:  pgText(appName),
-		State:            pgText(state),
-		ReplicationType:  pgText("physical"),
-		ReplayLagBytes:   pgInt8(0),
-		ReplayLagSeconds: pgFloat8(0),
-		SlotName:         pgText(fmt.Sprintf("%s_slot", appName)),
-		WalStatus:        pgText("reserved"),
+		ApplicationName:     pgText(appName),
+		State:               pgText(state),
+		ReplicationType:     pgText("physical"),
+		ReplayLagBytes:      pgInt8(0),
+		ReplayLagSeconds:    pgFloat8(0),
+		MaxSlotWalKeepBytes: pgInt8(capUnlimited),
+		SlotName:            pgText(fmt.Sprintf("%s_slot", appName)),
+		WalStatus:           pgText("reserved"),
 	}
 }
 
 func walIssue(appName, walStatus string) db.ReplicationLagRow {
 	return db.ReplicationLagRow{
-		ApplicationName:  pgText(appName),
-		State:            pgText("streaming"),
-		ReplicationType:  pgText("logical"),
-		ReplayLagBytes:   pgInt8(1024),
-		ReplayLagSeconds: pgFloat8(0.5),
-		SlotName:         pgText(fmt.Sprintf("%s_slot", appName)),
-		WalStatus:        pgText(walStatus),
+		ApplicationName:     pgText(appName),
+		State:               pgText("streaming"),
+		ReplicationType:     pgText("logical"),
+		ReplayLagBytes:      pgInt8(1024),
+		ReplayLagSeconds:    pgFloat8(0.5),
+		MaxSlotWalKeepBytes: pgInt8(capUnlimited),
+		SlotName:            pgText(fmt.Sprintf("%s_slot", appName)),
+		WalStatus:           pgText(walStatus),
 	}
 }
 
@@ -146,7 +162,7 @@ func TestCheck_AllHealthy(t *testing.T) {
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
 
-	// Should have 5 findings: replication-state, wal-retention, physical-lag, logical-lag (all OK)
+	// Should have 4 findings: replication-state, wal-retention, physical-lag, logical-lag (all OK)
 	assert.Len(t, report.Results, 4)
 	assert.Equal(t, check.SeverityOK, report.Severity)
 
@@ -255,7 +271,7 @@ func TestCheck_LogicalReplicationLag_Warning(t *testing.T) {
 
 	queryer := &mockQueryer{
 		rows: []db.ReplicationLagRow{
-			laggingLogical("debezium", 25.0), // 25s - warning (threshold: 20s)
+			laggingLogical("debezium", 130.0, 9*gib, capUnlimited), // high time AND bytes - warning
 		},
 	}
 	checker := replicationlag.New(queryer)
@@ -284,7 +300,7 @@ func TestCheck_LogicalReplicationLag_Fail(t *testing.T) {
 
 	queryer := &mockQueryer{
 		rows: []db.ReplicationLagRow{
-			laggingLogical("debezium", 40.0), // 40s - fail (threshold: 35s)
+			laggingLogical("debezium", 350.0, 9*gib, capUnlimited), // high time AND bytes - fail
 		},
 	}
 	checker := replicationlag.New(queryer)
@@ -312,13 +328,35 @@ func TestCheck_LogicalReplicationLag_Thresholds(t *testing.T) {
 	tests := []struct {
 		name           string
 		lagSeconds     float64
+		lagBytes       int64
+		capBytes       int64
 		expectSeverity check.Severity
 	}{
-		{"under threshold", 10.0, check.SeverityOK},
-		{"exactly at warn threshold", 20.0, check.SeverityWarn},
-		{"over warn threshold", 25.0, check.SeverityWarn},
-		{"exactly at fail threshold", 35.0, check.SeverityFail},
-		{"over fail threshold", 50.0, check.SeverityFail},
+		// --- Absolute tier (cap = -1 disables the relative tier) ---
+		// Reported healthy samples: high-ish time but tiny backlog stays OK.
+		{"57.59s with 149.3MiB backlog, no cap", 57.59, 149*mib + 307*1024, capUnlimited, check.SeverityOK},
+		{"20.76s with 34.1MiB backlog, no cap", 20.76, 34 * mib, capUnlimited, check.SeverityOK},
+		// Time alone is not enough — bytes below warn tier.
+		{"warn time but bytes below warn", 130.0, mib, capUnlimited, check.SeverityOK},
+		// Bytes alone is not enough — time below warn tier.
+		{"warn bytes but time below warn", 10.0, 9 * gib, capUnlimited, check.SeverityOK},
+		{"130s with 600MiB AND-gate warn", 130.0, 600 * mib, capUnlimited, check.SeverityWarn},
+		{"350s with 3GiB AND-gate fail", 350.0, 3 * gib, capUnlimited, check.SeverityFail},
+		// Fail time but bytes only in warn tier ⇒ degrades to warn.
+		{"fail time with warn-tier bytes degrades to warn", 350.0, 600 * mib, capUnlimited, check.SeverityWarn},
+		{"exactly at warn thresholds", 120.0, warnBytes, capUnlimited, check.SeverityWarn},
+		{"exactly at fail thresholds", 300.0, failBytes, capUnlimited, check.SeverityFail},
+
+		// --- Capacity-relative tier (low time, so the absolute tier is OK) ---
+		{"cap=1GiB backlog 600MiB (>=50%) warn", 5.0, 600 * mib, gib, check.SeverityWarn},
+		{"cap=1GiB backlog 950MiB (>=85%) fail", 5.0, 950 * mib, gib, check.SeverityFail},
+		{"cap=10GiB backlog 100MiB OK", 5.0, 100 * mib, 10 * gib, check.SeverityOK},
+
+		// --- Tiers disagree: max wins ---
+		// Absolute FAIL (350s/3GiB), relative OK (3GiB < 50% of 10GiB) ⇒ FAIL.
+		{"absolute fail, relative ok, max=fail", 350.0, 3 * gib, 10 * gib, check.SeverityFail},
+		// Absolute OK (low time), relative FAIL (950MiB >= 85% of 1GiB) ⇒ FAIL.
+		{"absolute ok, relative fail, max=fail", 5.0, 950 * mib, gib, check.SeverityFail},
 	}
 
 	for _, tt := range tests {
@@ -327,7 +365,7 @@ func TestCheck_LogicalReplicationLag_Thresholds(t *testing.T) {
 
 			queryer := &mockQueryer{
 				rows: []db.ReplicationLagRow{
-					laggingLogical("debezium", tt.lagSeconds),
+					laggingLogical("debezium", tt.lagSeconds, tt.lagBytes, tt.capBytes),
 				},
 			}
 			checker := replicationlag.New(queryer)
@@ -348,7 +386,7 @@ func TestCheck_MixedReplicationTypes(t *testing.T) {
 			healthyPhysical("standby1"),
 			laggingPhysical("standby2", 0.5), // warn
 			healthyLogical("debezium1"),
-			laggingLogical("debezium2", 40.0), // fail (threshold: 35s)
+			laggingLogical("debezium2", 350.0, 9*gib, capUnlimited), // fail: high time AND bytes
 		},
 	}
 	checker := replicationlag.New(queryer)
@@ -577,10 +615,10 @@ func TestCheck_MultipleIssues(t *testing.T) {
 
 	queryer := &mockQueryer{
 		rows: []db.ReplicationLagRow{
-			laggingPhysical("standby1", 2.0),         // physical lag fail
-			laggingLogical("debezium1", 40.0),        // logical lag fail (threshold: 35s)
-			nonStreamingState("standby2", "catchup"), // state warn
-			walIssue("debezium2", "unreserved"),      // wal fail
+			laggingPhysical("standby1", 2.0),                        // physical lag fail
+			laggingLogical("debezium1", 350.0, 9*gib, capUnlimited), // logical lag fail: time AND bytes
+			nonStreamingState("standby2", "catchup"),                // state warn
+			walIssue("debezium2", "unreserved"),                     // wal fail
 		},
 	}
 	checker := replicationlag.New(queryer)
@@ -645,13 +683,14 @@ func TestCheck_FormatBytes(t *testing.T) {
 	t.Parallel()
 
 	row := db.ReplicationLagRow{
-		ApplicationName:  pgText("debezium"),
-		State:            pgText("streaming"),
-		ReplicationType:  pgText("logical"),
-		ReplayLagBytes:   pgInt8(1536 * 1024 * 1024), // 1.5GiB
-		ReplayLagSeconds: pgFloat8(40.0),             // Lagging (threshold: 35s)
-		SlotName:         pgText("debezium_slot"),
-		WalStatus:        pgText("reserved"),
+		ApplicationName:     pgText("debezium"),
+		State:               pgText("streaming"),
+		ReplicationType:     pgText("logical"),
+		ReplayLagBytes:      pgInt8(3 * 1024 * 1024 * 1024), // 3GiB - above warn tier
+		ReplayLagSeconds:    pgFloat8(350.0),                // high time so the row lags
+		MaxSlotWalKeepBytes: pgInt8(capUnlimited),
+		SlotName:            pgText("debezium_slot"),
+		WalStatus:           pgText("reserved"),
 	}
 
 	queryer := &mockQueryer{rows: []db.ReplicationLagRow{row}}
@@ -673,20 +712,21 @@ func TestCheck_FormatBytes(t *testing.T) {
 
 	// Check lag bytes formatting (4th column, index 3)
 	lagBytesCell := logicalFinding.Table.Rows[0].Cells[3]
-	assert.Contains(t, lagBytesCell, "1.5GiB")
+	assert.Contains(t, lagBytesCell, "3.0GiB")
 }
 
 func TestCheck_FormatSeconds(t *testing.T) {
 	t.Parallel()
 
 	row := db.ReplicationLagRow{
-		ApplicationName:  pgText("debezium"),
-		State:            pgText("streaming"),
-		ReplicationType:  pgText("logical"),
-		ReplayLagBytes:   pgInt8(1024),
-		ReplayLagSeconds: pgFloat8(23.456), // Lagging (warn threshold: 20s)
-		SlotName:         pgText("debezium_slot"),
-		WalStatus:        pgText("reserved"),
+		ApplicationName:     pgText("debezium"),
+		State:               pgText("streaming"),
+		ReplicationType:     pgText("logical"),
+		ReplayLagBytes:      pgInt8(9 * 1024 * 1024 * 1024), // 9GiB so the row lags
+		ReplayLagSeconds:    pgFloat8(123.456),              // high time, lagging
+		MaxSlotWalKeepBytes: pgInt8(capUnlimited),
+		SlotName:            pgText("debezium_slot"),
+		WalStatus:           pgText("reserved"),
 	}
 
 	queryer := &mockQueryer{rows: []db.ReplicationLagRow{row}}
@@ -708,7 +748,7 @@ func TestCheck_FormatSeconds(t *testing.T) {
 
 	// Check lag seconds formatting (3rd column, index 2) - should be formatted to 2 decimals
 	lagSecondsCell := logicalFinding.Table.Rows[0].Cells[2]
-	assert.Equal(t, "23.46s", lagSecondsCell)
+	assert.Equal(t, "123.46s", lagSecondsCell)
 }
 
 func TestCheck_QueryError(t *testing.T) {
@@ -746,7 +786,7 @@ func TestCheck_PrescriptionsPresent(t *testing.T) {
 	queryer := &mockQueryer{
 		rows: []db.ReplicationLagRow{
 			laggingPhysical("standby1", 2.0),
-			laggingLogical("debezium1", 40.0), // fail (threshold: 35s)
+			laggingLogical("debezium1", 350.0, 9*gib, capUnlimited), // fail: time AND bytes
 			nonStreamingState("standby2", "catchup"),
 			walIssue("debezium2", "lost"),
 		},

--- a/checks/replicationlag/query.sql
+++ b/checks/replicationlag/query.sql
@@ -23,8 +23,22 @@ SELECT
   , rs.slot_name::text AS slot_name
   , rs.wal_status::text AS wal_status
 
+  -- Cluster-wide WAL retention budget as bytes; -1 means unlimited (passed through
+  -- verbatim). max_slot_wal_keep_size reports unit 'MB' with setting as an integer
+  -- count of MB, so multiply by 1 MiB. The -1 guard avoids misreading the sentinel
+  -- as a size. (PG13+; cluster-wide GUC, so a single constant via CROSS JOIN.)
+  , cap.max_slot_wal_keep_bytes AS max_slot_wal_keep_bytes
+
 FROM pg_stat_replication AS sr
 LEFT JOIN pg_replication_slots AS rs ON sr.pid = rs.active_pid
+CROSS JOIN LATERAL (
+  SELECT CASE
+           WHEN s.setting = '-1' THEN -1::bigint
+           ELSE s.setting::bigint * 1024 * 1024
+         END AS max_slot_wal_keep_bytes
+  FROM pg_settings AS s
+  WHERE s.name = 'max_slot_wal_keep_size'
+) AS cap
 ORDER BY
   EXTRACT(EPOCH FROM sr.replay_lag) DESC NULLS LAST
   , sr.application_name;

--- a/checks/sessionsettings/README.md
+++ b/checks/sessionsettings/README.md
@@ -11,6 +11,25 @@ By default, application roles are **discovered dynamically** — any login-capab
 - **idle_in_transaction_session_timeout**: Timeout for idle transactions
 - **log_min_duration_statement**: Threshold for logging slow queries
 
+## Precedence model
+
+For each `(role, setting)` pair, the check resolves the value the role would actually see when it connects to the current database, walking the PostgreSQL GUC hierarchy from most-specific to least-specific:
+
+| Priority | Source                                              | `pg_db_role_setting` row              |
+|----------|-----------------------------------------------------|---------------------------------------|
+| 1        | `ALTER ROLE r IN DATABASE d SET ...`                | `setrole=r.oid`, `setdatabase=d.oid`  |
+| 2        | `ALTER ROLE r SET ...`                              | `setrole=r.oid`, `setdatabase=0`      |
+| 3        | `ALTER DATABASE d SET ...` / `ALTER ROLE ALL IN DATABASE d SET ...` | `setrole=0`, `setdatabase=d.oid` |
+| 4        | `ALTER ROLE ALL SET ...`                            | `setrole=0`, `setdatabase=0`          |
+| 5        | Cluster default (`postgresql.conf` / `ALTER SYSTEM` / built-in) | `pg_settings.reset_val` fallback |
+
+The `status` column in the SQL result reports which level the value came from (`OVERRIDE_ROLE_DB`, `OVERRIDE_ROLE`, `OVERRIDE_DATABASE`, `OVERRIDE_ALL`, `DEFAULT`) so the origin of any value is debuggable from the raw query.
+
+### Caveats
+
+- Level-5 fallback uses `pg_settings.reset_val`, which reflects what the *connecting* session would receive on `RESET` — including any `ALTER ROLE` overrides on the role pgdoctor itself connects as. To keep that fallback accurate for other roles, **run pgdoctor as a role with no overrides on the inspected settings**.
+- Switching the cluster-default fallback to `pg_file_settings` + `boot_val` is a planned follow-up. It removes the caveat above but requires granting pgdoctor membership in the `pg_read_all_settings` predefined role, which is why it's intentionally out of scope for this check today.
+
 ## Why it matters
 
 Proper session settings prevent critical production issues:

--- a/checks/sessionsettings/check.go
+++ b/checks/sessionsettings/check.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -387,68 +386,11 @@ func (s dbSessionSettings) fetch(user, name string) (value int64, found bool, er
 		if !n.SettingName.Valid || n.SettingName.String != name || !n.SettingValue.Valid {
 			continue
 		}
-		ms, err := parseDurationMs(n.SettingValue.String, n.Unit.String)
+		ms, err := check.ParseDurationMs(n.SettingValue.String, n.Unit.String)
 		if err != nil {
 			return 0, false, fmt.Errorf("setting %s for user %s has invalid value %q: %w", name, user, n.SettingValue.String, err)
 		}
 		return ms, true, nil
 	}
 	return 0, false, nil
-}
-
-// timeUnitFactors maps GUC time-unit suffixes to a millisecond multiplier.
-// PostgreSQL only recognises these lowercase, case-sensitive suffixes; there is
-// no bare "m" time unit ("min" is the only minute spelling).
-var timeUnitFactors = map[string]float64{
-	"us":  1.0 / 1000,
-	"ms":  1,
-	"s":   1000,
-	"min": 60000,
-	"h":   3600000,
-	"d":   86400000,
-}
-
-// parseDurationMs converts a pg_settings value to integer milliseconds.
-//
-// ALTER ROLE stores values literally, so value may carry a unit suffix
-// ("2000ms", "1.5s", "2000 ms") or be a bare number interpreted in baseUnit.
-// The sign is preserved so sentinel values like -1 (disabled) survive.
-func parseDurationMs(value, baseUnit string) (int64, error) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return 0, fmt.Errorf("empty value")
-	}
-
-	// Match the longest trailing alphabetic suffix that is a known time unit.
-	numeric, factor := value, factorForUnit(baseUnit)
-	for i := len(value) - 1; i >= 0; i-- {
-		if !isASCIILetter(value[i]) {
-			suffix := value[i+1:]
-			if f, ok := timeUnitFactors[suffix]; ok {
-				numeric = strings.TrimSpace(value[:i+1])
-				factor = f
-			}
-			break
-		}
-	}
-
-	n, err := strconv.ParseFloat(numeric, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parsing numeric part %q: %w", numeric, err)
-	}
-
-	return int64(math.Round(n * factor)), nil
-}
-
-// factorForUnit returns the ms multiplier for a row's base Unit, defaulting to
-// milliseconds when the unit is empty or not a recognised time unit.
-func factorForUnit(unit string) float64 {
-	if f, ok := timeUnitFactors[unit]; ok {
-		return f
-	}
-	return 1
-}
-
-func isASCIILetter(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }

--- a/checks/sessionsettings/check.go
+++ b/checks/sessionsettings/check.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -184,17 +185,17 @@ func (c *checker) Check(ctx context.Context) (*check.Report, error) {
 func (c *checker) checkUserTimeouts(s dbSessionSettings, user string) ([]settingCheck, error) {
 	var checks []settingCheck
 
-	stmtTimeout, err := s.fetch(user, "statement_timeout")
+	stmtTimeout, _, err := s.fetch(user, "statement_timeout")
 	if err != nil {
 		return nil, fmt.Errorf("fetching statement_timeout: %w", err)
 	}
 
-	idleTimeout, err := s.fetch(user, "idle_in_transaction_session_timeout")
+	idleTimeout, _, err := s.fetch(user, "idle_in_transaction_session_timeout")
 	if err != nil {
 		return nil, fmt.Errorf("fetching idle_in_transaction_session_timeout: %w", err)
 	}
 
-	txTimeout, err := s.fetch(user, "transaction_timeout")
+	txTimeout, txFound, err := s.fetch(user, "transaction_timeout")
 	if err != nil {
 		return nil, fmt.Errorf("fetching transaction_timeout: %w", err)
 	}
@@ -260,43 +261,47 @@ func (c *checker) checkUserTimeouts(s dbSessionSettings, user string) ([]setting
 		})
 	}
 
-	// Check transaction_timeout
-	if txTimeout == 0 {
-		checks = append(checks, settingCheck{
-			Role:      user,
-			Parameter: "transaction_timeout",
-			Current:   "0ms (disabled)",
-			Expected:  expectedTimeout,
-			Status:    "MUST be set (PG17+)",
-			Severity:  check.SeverityFail,
-		})
-	} else if txTimeout > c.timeoutFail {
-		checks = append(checks, settingCheck{
-			Role:      user,
-			Parameter: "transaction_timeout",
-			Current:   fmt.Sprintf("%dms", txTimeout),
-			Expected:  expectedTimeout,
-			Status:    "Too high",
-			Severity:  check.SeverityFail,
-		})
-	} else if txTimeout > c.timeoutWarn {
-		checks = append(checks, settingCheck{
-			Role:      user,
-			Parameter: "transaction_timeout",
-			Current:   fmt.Sprintf("%dms", txTimeout),
-			Expected:  expectedTimeout,
-			Status:    "High",
-			Severity:  check.SeverityWarn,
-		})
-	} else {
-		checks = append(checks, settingCheck{
-			Role:      user,
-			Parameter: "transaction_timeout",
-			Current:   fmt.Sprintf("%dms", txTimeout),
-			Expected:  expectedTimeout,
-			Status:    "OK",
-			Severity:  check.SeverityOK,
-		})
+	// Check transaction_timeout (PG17+). When the row is absent the server
+	// predates PG17 and lacks the setting entirely — skip it rather than
+	// false-FAILing every role.
+	if txFound {
+		if txTimeout == 0 {
+			checks = append(checks, settingCheck{
+				Role:      user,
+				Parameter: "transaction_timeout",
+				Current:   "0ms (disabled)",
+				Expected:  expectedTimeout,
+				Status:    "MUST be set (PG17+)",
+				Severity:  check.SeverityFail,
+			})
+		} else if txTimeout > c.timeoutFail {
+			checks = append(checks, settingCheck{
+				Role:      user,
+				Parameter: "transaction_timeout",
+				Current:   fmt.Sprintf("%dms", txTimeout),
+				Expected:  expectedTimeout,
+				Status:    "Too high",
+				Severity:  check.SeverityFail,
+			})
+		} else if txTimeout > c.timeoutWarn {
+			checks = append(checks, settingCheck{
+				Role:      user,
+				Parameter: "transaction_timeout",
+				Current:   fmt.Sprintf("%dms", txTimeout),
+				Expected:  expectedTimeout,
+				Status:    "High",
+				Severity:  check.SeverityWarn,
+			})
+		} else {
+			checks = append(checks, settingCheck{
+				Role:      user,
+				Parameter: "transaction_timeout",
+				Current:   fmt.Sprintf("%dms", txTimeout),
+				Expected:  expectedTimeout,
+				Status:    "OK",
+				Severity:  check.SeverityOK,
+			})
+		}
 	}
 
 	return checks, nil
@@ -305,7 +310,7 @@ func (c *checker) checkUserTimeouts(s dbSessionSettings, user string) ([]setting
 func checkLogStatements(s dbSessionSettings, user string) ([]settingCheck, error) {
 	var checks []settingCheck
 
-	minDuration, err := s.fetch(user, "log_min_duration_statement")
+	minDuration, _, err := s.fetch(user, "log_min_duration_statement")
 	if err != nil {
 		return nil, fmt.Errorf("fetching log_min_duration_statement: %w", err)
 	}
@@ -370,19 +375,80 @@ func (s dbSessionSettings) hasRole(role string) bool {
 	return false
 }
 
-// fetch returns the integer value of a setting for a user.
-// Returns (0, nil) when the setting is not found — treats missing as disabled/default.
-func (s dbSessionSettings) fetch(user string, name string) (int64, error) {
+// fetch returns the millisecond value of a setting for a user.
+// found is false when no matching row with a valid value exists — for
+// version-gated settings (e.g. transaction_timeout on PG<17) the query emits no
+// row at all, so absence is the only reliable "unsupported version" signal.
+func (s dbSessionSettings) fetch(user, name string) (value int64, found bool, err error) {
 	for _, n := range s {
-		if n.RoleName.Valid && n.RoleName.String == user {
-			if n.SettingName.Valid && n.SettingName.String == name && n.SettingValue.Valid {
-				intVal, err := strconv.ParseInt(n.SettingValue.String, 10, 64)
-				if err != nil {
-					return 0, fmt.Errorf("setting %s for user %s has invalid integer value: %w", name, user, err)
-				}
-				return intVal, nil
+		if !n.RoleName.Valid || n.RoleName.String != user {
+			continue
+		}
+		if !n.SettingName.Valid || n.SettingName.String != name || !n.SettingValue.Valid {
+			continue
+		}
+		ms, err := parseDurationMs(n.SettingValue.String, n.Unit.String)
+		if err != nil {
+			return 0, false, fmt.Errorf("setting %s for user %s has invalid value %q: %w", name, user, n.SettingValue.String, err)
+		}
+		return ms, true, nil
+	}
+	return 0, false, nil
+}
+
+// timeUnitFactors maps GUC time-unit suffixes to a millisecond multiplier.
+// PostgreSQL only recognises these lowercase, case-sensitive suffixes; there is
+// no bare "m" time unit ("min" is the only minute spelling).
+var timeUnitFactors = map[string]float64{
+	"us":  1.0 / 1000,
+	"ms":  1,
+	"s":   1000,
+	"min": 60000,
+	"h":   3600000,
+	"d":   86400000,
+}
+
+// parseDurationMs converts a pg_settings value to integer milliseconds.
+//
+// ALTER ROLE stores values literally, so value may carry a unit suffix
+// ("2000ms", "1.5s", "2000 ms") or be a bare number interpreted in baseUnit.
+// The sign is preserved so sentinel values like -1 (disabled) survive.
+func parseDurationMs(value, baseUnit string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, fmt.Errorf("empty value")
+	}
+
+	// Match the longest trailing alphabetic suffix that is a known time unit.
+	numeric, factor := value, factorForUnit(baseUnit)
+	for i := len(value) - 1; i >= 0; i-- {
+		if !isASCIILetter(value[i]) {
+			suffix := value[i+1:]
+			if f, ok := timeUnitFactors[suffix]; ok {
+				numeric = strings.TrimSpace(value[:i+1])
+				factor = f
 			}
+			break
 		}
 	}
-	return 0, nil // not found → treat as disabled/default
+
+	n, err := strconv.ParseFloat(numeric, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing numeric part %q: %w", numeric, err)
+	}
+
+	return int64(math.Round(n * factor)), nil
+}
+
+// factorForUnit returns the ms multiplier for a row's base Unit, defaulting to
+// milliseconds when the unit is empty or not a recognised time unit.
+func factorForUnit(unit string) float64 {
+	if f, ok := timeUnitFactors[unit]; ok {
+		return f
+	}
+	return 1
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }

--- a/checks/sessionsettings/check_test.go
+++ b/checks/sessionsettings/check_test.go
@@ -83,6 +83,29 @@ func removeFromSessionSettings(role, name string) []db.SessionSettingsRow {
 	return mapToSessionSettingsRows(settings)
 }
 
+// removeFromAllRoles drops a setting from every role, simulating a server that
+// lacks the setting (e.g. transaction_timeout on PG<17 emits no row).
+func removeFromAllRoles(name string) []db.SessionSettingsRow {
+	settings := optimalSessionSettings()
+	for role := range settings {
+		delete(settings[role], name)
+	}
+
+	return mapToSessionSettingsRows(settings)
+}
+
+// setUnit stamps the row matching role/name with the given base Unit, mirroring
+// what the real query returns from pg_settings.unit.
+func setUnit(rows []db.SessionSettingsRow, role, name, unit string) []db.SessionSettingsRow {
+	for i := range rows {
+		if rows[i].RoleName.String == role && rows[i].SettingName.String == name {
+			rows[i].Unit = pgtype.Text{String: unit, Valid: true}
+		}
+	}
+
+	return rows
+}
+
 func Test_SessionSettings(t *testing.T) {
 	t.Parallel()
 
@@ -123,6 +146,18 @@ func Test_SessionSettings(t *testing.T) {
 			},
 		},
 		{
+			// ALTER ROLE stores unit-suffixed values literally. "2000ms" must
+			// parse to 2000 (≤ 5000 warn threshold) instead of crashing the check.
+			Name: "statement_timeout unit-suffixed 2000ms for app_ro is OK",
+			Rows: setUnit(
+				overrideOptimalSessionSettings("app_ro", "statement_timeout", "2000ms"),
+				"app_ro", "statement_timeout", "ms",
+			),
+			Expect: []ExpectedResultCheck{
+				{ID: "session-settings", Sev: check.SeverityOK},
+			},
+		},
+		{
 			Name: "statement_timeout disabled for both roles",
 			Rows: overrideBothRoles("statement_timeout", "0"),
 			Expect: []ExpectedResultCheck{
@@ -146,13 +181,24 @@ func Test_SessionSettings(t *testing.T) {
 		},
 		// Transaction timeout tests
 		{
-			Name: "transaction_timeout missing for app_ro (PG < 17)",
+			// Row absent ⇒ server predates PG17 ⇒ transaction_timeout is skipped,
+			// not failed. The remaining optimal settings keep the check OK.
+			Name: "transaction_timeout missing for app_ro (PG < 17) is skipped",
 			Rows: removeFromSessionSettings("app_ro", "transaction_timeout"),
 			Expect: []ExpectedResultCheck{
-				{ID: "session-settings", Sev: check.SeverityFail},
+				{ID: "session-settings", Sev: check.SeverityOK},
 			},
 		},
 		{
+			// All roles lack the row ⇒ PG<17 ⇒ no transaction_timeout finding at all.
+			Name: "transaction_timeout absent for all roles (PG < 17) yields no finding",
+			Rows: removeFromAllRoles("transaction_timeout"),
+			Expect: []ExpectedResultCheck{
+				{ID: "session-settings", Sev: check.SeverityOK},
+			},
+		},
+		{
+			// PG17+ present with value 0 must still FAIL (regression guard).
 			Name: "transaction_timeout disabled for app_ro",
 			Rows: overrideOptimalSessionSettings("app_ro", "transaction_timeout", "0"),
 			Expect: []ExpectedResultCheck{
@@ -219,6 +265,38 @@ func Test_SessionSettings(t *testing.T) {
 				require.NotNil(t, result.Table, "Non-OK result should have a table")
 				require.Greater(t, len(result.Table.Rows), 0, "Table should have rows")
 			}
+		})
+	}
+}
+
+func Test_ParseDurationMs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    string
+		baseUnit string
+		expect   int64
+	}{
+		{name: "ms suffix", value: "2000ms", expect: 2000},
+		{name: "seconds suffix", value: "2s", expect: 2000},
+		{name: "minutes suffix", value: "1min", expect: 60000},
+		{name: "bare number defaults to ms", value: "2000", expect: 2000},
+		{name: "zero", value: "0", expect: 0},
+		{name: "disabled sentinel keeps sign", value: "-1", expect: -1},
+		{name: "fractional seconds", value: "1.5s", expect: 1500},
+		{name: "space before unit", value: "2000 ms", expect: 2000},
+		{name: "bare number with ms base unit", value: "2000", baseUnit: "ms", expect: 2000},
+		{name: "microseconds round to nearest ms", value: "1500us", expect: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := sessionsettings.ParseDurationMs(tt.value, tt.baseUnit)
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, got)
 		})
 	}
 }

--- a/checks/sessionsettings/check_test.go
+++ b/checks/sessionsettings/check_test.go
@@ -269,38 +269,6 @@ func Test_SessionSettings(t *testing.T) {
 	}
 }
 
-func Test_ParseDurationMs(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		value    string
-		baseUnit string
-		expect   int64
-	}{
-		{name: "ms suffix", value: "2000ms", expect: 2000},
-		{name: "seconds suffix", value: "2s", expect: 2000},
-		{name: "minutes suffix", value: "1min", expect: 60000},
-		{name: "bare number defaults to ms", value: "2000", expect: 2000},
-		{name: "zero", value: "0", expect: 0},
-		{name: "disabled sentinel keeps sign", value: "-1", expect: -1},
-		{name: "fractional seconds", value: "1.5s", expect: 1500},
-		{name: "space before unit", value: "2000 ms", expect: 2000},
-		{name: "bare number with ms base unit", value: "2000", baseUnit: "ms", expect: 2000},
-		{name: "microseconds round to nearest ms", value: "1500us", expect: 2},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got, err := sessionsettings.ParseDurationMs(tt.value, tt.baseUnit)
-			require.NoError(t, err)
-			require.Equal(t, tt.expect, got)
-		})
-	}
-}
-
 func Test_SessionSettings_MultipleIssues(t *testing.T) {
 	t.Parallel()
 

--- a/checks/sessionsettings/export_test.go
+++ b/checks/sessionsettings/export_test.go
@@ -1,4 +1,0 @@
-package sessionsettings
-
-// ParseDurationMs exposes the unexported duration parser for white-box tests.
-var ParseDurationMs = parseDurationMs

--- a/checks/sessionsettings/export_test.go
+++ b/checks/sessionsettings/export_test.go
@@ -1,0 +1,4 @@
+package sessionsettings
+
+// ParseDurationMs exposes the unexported duration parser for white-box tests.
+var ParseDurationMs = parseDurationMs

--- a/checks/sessionsettings/query.sql
+++ b/checks/sessionsettings/query.sql
@@ -1,22 +1,27 @@
 -- name: SessionSettings :many
 /*
- * PostgreSQL settings follow a precedence hierarchy:
- * 1. System defaults (postgresql.conf)
- * 2. Database-level overrides (ALTER DATABASE ... SET)
- * 3. Role-level overrides (ALTER ROLE ... SET)  <- This query checks these
- * 4. Session-level changes (SET command)
+ * PostgreSQL GUC precedence for ALTER ROLE / ALTER DATABASE settings,
+ * from most specific to least:
  *
- * Technical approach:
- * - Dynamically discovers application roles (login-capable, non-system)
- * - pg_db_role_setting stores role configs as text arrays: ['key=value', ...]
- * - UNNEST + split_part parse these into usable key/value pairs
- * - CROSS JOIN creates full matrix of roles × settings (shows gaps)
- * - LEFT JOIN preserves NULLs to identify which settings use defaults
- * - setdatabase = 0 filters for cluster-wide settings (not DB-specific)
+ *   1. ALTER ROLE r IN DATABASE d SET ...     (setrole=r.oid, setdatabase=d.oid)
+ *   2. ALTER ROLE r SET ...                   (setrole=r.oid, setdatabase=0)
+ *   3. ALTER DATABASE d SET ... / ALTER ROLE ALL IN DATABASE d
+ *                                             (setrole=0,     setdatabase=d.oid)
+ *   4. ALTER ROLE ALL SET ...                 (setrole=0,     setdatabase=0)
+ *   5. postgresql.conf / ALTER SYSTEM / built-in default
  *
- * NOTE: reset_val represents the effective default (includes DB-level overrides),
- * not the raw postgresql.conf value. This is appropriate since we want to know
- * what the role actually gets vs what they override.
+ * For each application role and inspected setting, this query returns the
+ * value the role would actually see on connect to the current database —
+ * i.e., the most-specific row from pg_db_role_setting, falling back to
+ * pg_settings.reset_val when no override at levels 1-4 applies.
+ *
+ * Caveat: pg_settings.reset_val reflects what the *connecting* session
+ * would get on RESET, including any ALTER ROLE settings on the role
+ * pgdoctor connects as. Run pgdoctor as a role with no overrides for the
+ * inspected settings, otherwise the level-5 fallback can be wrong for
+ * other roles. (Switching to pg_file_settings + boot_val to remove this
+ * caveat is a planned follow-up; it requires the pg_read_all_settings
+ * predefined role.)
  */
 WITH roles AS (
   SELECT r.rolname, r.oid
@@ -34,10 +39,7 @@ WITH roles AS (
 )
 
 , settings AS (
-  SELECT
-    s.name
-    , s.reset_val
-    , s.unit
+  SELECT s.name, s.reset_val, s.unit
   FROM pg_settings AS s
   WHERE s.name IN (
     'statement_timeout'
@@ -47,44 +49,82 @@ WITH roles AS (
   )
 )
 
-, role_configs AS (
-  SELECT
-    r.rolname
-    , unnest(coalesce(
-      (
-        SELECT drs.setconfig
-        FROM pg_db_role_setting AS drs
-        WHERE
-          drs.setrole = r.oid
-          AND drs.setdatabase = 0
-      )
-      , ARRAY[]::text []
-    )) AS config_setting
-  FROM roles AS r
+, current_db AS (
+  SELECT d.oid FROM pg_database AS d WHERE d.datname = current_database()
 )
 
-, parsed_configs AS (
+-- Every pg_db_role_setting entry that could apply, parsed into key/value.
+-- Filtered to our inspected settings so the join below stays tiny.
+-- substring(... from position('=' in ...) + 1) handles values that contain '='.
+, overrides AS (
   SELECT
+    drs.setrole AS role_oid
+    , drs.setdatabase AS db_oid
+    , split_part(cfg, '=', 1) AS param_name
+    , substring(cfg FROM position('=' IN cfg) + 1) AS param_value
+  FROM pg_db_role_setting AS drs
+  CROSS JOIN LATERAL unnest(coalesce(drs.setconfig, ARRAY[]::text [])) AS cfg
+  WHERE split_part(cfg, '=', 1) IN (
+    'statement_timeout'
+    , 'idle_in_transaction_session_timeout'
+    , 'transaction_timeout'
+    , 'log_min_duration_statement'
+  )
+)
+
+-- Cross every role with every setting; LEFT JOIN every candidate override.
+-- Each (role, setting) row can produce up to 4 candidate rows; we pick the
+-- most-specific one (lowest priority number) via DISTINCT ON below.
+, candidates AS (
+  SELECT
+    r.rolname
+    , s.name AS setting_name
+    , s.reset_val AS system_default
+    , s.unit
+    , o.param_value AS override_value
+    , CASE
+      WHEN o.role_oid = r.oid AND o.db_oid = cdb.oid THEN 1
+      WHEN o.role_oid = r.oid AND o.db_oid = 0 THEN 2
+      WHEN o.role_oid = 0 AND o.db_oid = cdb.oid THEN 3
+      WHEN o.role_oid = 0 AND o.db_oid = 0 THEN 4
+    END AS priority
+  FROM roles AS r
+  CROSS JOIN settings AS s
+  CROSS JOIN current_db AS cdb
+  LEFT JOIN overrides AS o
+    ON o.param_name = s.name
+    AND (
+      (o.role_oid = r.oid AND o.db_oid = cdb.oid)
+      OR (o.role_oid = r.oid AND o.db_oid = 0)
+      OR (o.role_oid = 0 AND o.db_oid = cdb.oid)
+      OR (o.role_oid = 0 AND o.db_oid = 0)
+    )
+)
+
+, winners AS (
+  SELECT DISTINCT ON (rolname, setting_name)
     rolname
-    , split_part(config_setting, '=', 1) AS param_name
-    , split_part(config_setting, '=', 2) AS param_value
-  FROM role_configs
+    , setting_name
+    , system_default
+    , unit
+    , override_value
+    , priority
+  FROM candidates
+  ORDER BY rolname, setting_name, priority NULLS LAST
 )
 
 SELECT
-  r.rolname::varchar AS role_name
-  , s.name::varchar AS setting_name
-  , s.reset_val AS system_default
-  , s.unit
-  , coalesce(pc.param_value, s.reset_val) AS setting_value
-  , CASE
-    WHEN pc.param_value IS NOT NULL THEN 'OVERRIDE'
+  rolname::varchar AS role_name
+  , setting_name::varchar AS setting_name
+  , system_default
+  , unit
+  , coalesce(override_value, system_default) AS setting_value
+  , CASE priority
+    WHEN 1 THEN 'OVERRIDE_ROLE_DB'
+    WHEN 2 THEN 'OVERRIDE_ROLE'
+    WHEN 3 THEN 'OVERRIDE_DATABASE'
+    WHEN 4 THEN 'OVERRIDE_ALL'
     ELSE 'DEFAULT'
   END AS status
-FROM roles AS r
-CROSS JOIN settings AS s
-LEFT JOIN parsed_configs AS pc
-  ON
-    r.rolname = pc.rolname
-    AND s.name = pc.param_name
-ORDER BY r.rolname, s.name;
+FROM winners
+ORDER BY rolname, setting_name;

--- a/db/query.sql.go
+++ b/db/query.sql.go
@@ -175,7 +175,6 @@ func (q *Queries) DatabaseFreezeAge(ctx context.Context) ([]DatabaseFreezeAgeRow
 	return items, nil
 }
 
-
 const duplicateIndexes = `-- name: DuplicateIndexes :many
 WITH index_columns AS (
   SELECT
@@ -970,84 +969,6 @@ func (q *Queries) LongIdleConnections(ctx context.Context) ([]LongIdleConnection
 	return items, nil
 }
 
-const missingProviderIdTables = `-- name: MissingProviderIdTables :many
-WITH user_tables AS (
-  SELECT
-    (n.nspname || '.' || c.relname)::text AS table_name
-    , c.oid AS table_oid
-    , pg_catalog.pg_table_size(c.oid) AS table_size_bytes
-    , CASE
-      WHEN c.relkind = 'p'
-        THEN (
-          -- For partitioned tables, sum stats from all child partitions
-          SELECT COALESCE(SUM(child_stats.n_live_tup), 0)::bigint
-          FROM pg_catalog.pg_inherits AS i
-          INNER JOIN pg_stat_user_tables AS child_stats ON i.inhrelid = child_stats.relid
-          WHERE i.inhparent = c.oid
-        )
-      ELSE COALESCE(s.n_live_tup, 0)
-    END AS estimated_rows
-  FROM pg_catalog.pg_class AS c
-  INNER JOIN pg_catalog.pg_namespace AS n ON c.relnamespace = n.oid
-  LEFT JOIN pg_stat_user_tables AS s ON c.oid = s.relid
-  WHERE
-    c.relkind IN ('r', 'p')
-    AND n.nspname = 'public'
-)
-
-, tables_with_provider_id AS (
-  SELECT DISTINCT a.attrelid AS table_oid
-  FROM pg_catalog.pg_attribute AS a
-  WHERE
-    a.attname = 'provider_id'
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-)
-
-SELECT
-  CURRENT_DATABASE()::text AS database_name
-  , ut.table_name
-  , ut.table_size_bytes
-  , ut.estimated_rows
-FROM user_tables AS ut
-LEFT JOIN tables_with_provider_id AS t ON ut.table_oid = t.table_oid
-WHERE t.table_oid IS NULL
-ORDER BY ut.table_size_bytes DESC
-`
-
-type MissingProviderIdTablesRow struct {
-	DatabaseName   pgtype.Text
-	TableName      pgtype.Text
-	TableSizeBytes pgtype.Int8
-	EstimatedRows  pgtype.Int8
-}
-
-// Identifies tables without provider_id column for multi-tenancy support.
-func (q *Queries) MissingProviderIdTables(ctx context.Context) ([]MissingProviderIdTablesRow, error) {
-	rows, err := q.db.Query(ctx, missingProviderIdTables)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []MissingProviderIdTablesRow
-	for rows.Next() {
-		var i MissingProviderIdTablesRow
-		if err := rows.Scan(
-			&i.DatabaseName,
-			&i.TableName,
-			&i.TableSizeBytes,
-			&i.EstimatedRows,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const pGVersion = `-- name: PGVersion :one
 SELECT
   current_setting('server_version_num')::integer / 10000 AS major
@@ -1239,21 +1160,36 @@ SELECT
   , rs.slot_name::text AS slot_name
   , rs.wal_status::text AS wal_status
 
+  -- Cluster-wide WAL retention budget as bytes; -1 means unlimited (passed through
+  -- verbatim). max_slot_wal_keep_size reports unit 'MB' with setting as an integer
+  -- count of MB, so multiply by 1 MiB. The -1 guard avoids misreading the sentinel
+  -- as a size. (PG13+; cluster-wide GUC, so a single constant via CROSS JOIN.)
+  , cap.max_slot_wal_keep_bytes AS max_slot_wal_keep_bytes
+
 FROM pg_stat_replication AS sr
 LEFT JOIN pg_replication_slots AS rs ON sr.pid = rs.active_pid
+CROSS JOIN LATERAL (
+  SELECT CASE
+           WHEN s.setting = '-1' THEN -1::bigint
+           ELSE s.setting::bigint * 1024 * 1024
+         END AS max_slot_wal_keep_bytes
+  FROM pg_settings AS s
+  WHERE s.name = 'max_slot_wal_keep_size'
+) AS cap
 ORDER BY
   EXTRACT(EPOCH FROM sr.replay_lag) DESC NULLS LAST
   , sr.application_name
 `
 
 type ReplicationLagRow struct {
-	ApplicationName  pgtype.Text
-	State            pgtype.Text
-	ReplicationType  pgtype.Text
-	ReplayLagBytes   pgtype.Int8
-	ReplayLagSeconds pgtype.Float8
-	SlotName         pgtype.Text
-	WalStatus        pgtype.Text
+	ApplicationName     pgtype.Text
+	State               pgtype.Text
+	ReplicationType     pgtype.Text
+	ReplayLagBytes      pgtype.Int8
+	ReplayLagSeconds    pgtype.Float8
+	SlotName            pgtype.Text
+	WalStatus           pgtype.Text
+	MaxSlotWalKeepBytes pgtype.Int8
 }
 
 // Monitors replication lag for both physical and logical replication streams.
@@ -1275,6 +1211,7 @@ func (q *Queries) ReplicationLag(ctx context.Context) ([]ReplicationLagRow, erro
 			&i.ReplayLagSeconds,
 			&i.SlotName,
 			&i.WalStatus,
+			&i.MaxSlotWalKeepBytes,
 		); err != nil {
 			return nil, err
 		}
@@ -1620,23 +1557,28 @@ func (q *Queries) SequenceHealth(ctx context.Context) ([]SequenceHealthRow, erro
 
 const sessionSettings = `-- name: SessionSettings :many
 /*
- * PostgreSQL settings follow a precedence hierarchy:
- * 1. System defaults (postgresql.conf)
- * 2. Database-level overrides (ALTER DATABASE ... SET)
- * 3. Role-level overrides (ALTER ROLE ... SET)  <- This query checks these
- * 4. Session-level changes (SET command)
+ * PostgreSQL GUC precedence for ALTER ROLE / ALTER DATABASE settings,
+ * from most specific to least:
  *
- * Technical approach:
- * - Dynamically discovers application roles (login-capable, non-system)
- * - pg_db_role_setting stores role configs as text arrays: ['key=value', ...]
- * - UNNEST + split_part parse these into usable key/value pairs
- * - CROSS JOIN creates full matrix of roles × settings (shows gaps)
- * - LEFT JOIN preserves NULLs to identify which settings use defaults
- * - setdatabase = 0 filters for cluster-wide settings (not DB-specific)
+ *   1. ALTER ROLE r IN DATABASE d SET ...     (setrole=r.oid, setdatabase=d.oid)
+ *   2. ALTER ROLE r SET ...                   (setrole=r.oid, setdatabase=0)
+ *   3. ALTER DATABASE d SET ... / ALTER ROLE ALL IN DATABASE d
+ *                                             (setrole=0,     setdatabase=d.oid)
+ *   4. ALTER ROLE ALL SET ...                 (setrole=0,     setdatabase=0)
+ *   5. postgresql.conf / ALTER SYSTEM / built-in default
  *
- * NOTE: reset_val represents the effective default (includes DB-level overrides),
- * not the raw postgresql.conf value. This is appropriate since we want to know
- * what the role actually gets vs what they override.
+ * For each application role and inspected setting, this query returns the
+ * value the role would actually see on connect to the current database —
+ * i.e., the most-specific row from pg_db_role_setting, falling back to
+ * pg_settings.reset_val when no override at levels 1-4 applies.
+ *
+ * Caveat: pg_settings.reset_val reflects what the *connecting* session
+ * would get on RESET, including any ALTER ROLE settings on the role
+ * pgdoctor connects as. Run pgdoctor as a role with no overrides for the
+ * inspected settings, otherwise the level-5 fallback can be wrong for
+ * other roles. (Switching to pg_file_settings + boot_val to remove this
+ * caveat is a planned follow-up; it requires the pg_read_all_settings
+ * predefined role.)
  */
 WITH roles AS (
   SELECT r.rolname, r.oid
@@ -1654,10 +1596,7 @@ WITH roles AS (
 )
 
 , settings AS (
-  SELECT
-    s.name
-    , s.reset_val
-    , s.unit
+  SELECT s.name, s.reset_val, s.unit
   FROM pg_settings AS s
   WHERE s.name IN (
     'statement_timeout'
@@ -1667,47 +1606,79 @@ WITH roles AS (
   )
 )
 
-, role_configs AS (
-  SELECT
-    r.rolname
-    , unnest(coalesce(
-      (
-        SELECT drs.setconfig
-        FROM pg_db_role_setting AS drs
-        WHERE
-          drs.setrole = r.oid
-          AND drs.setdatabase = 0
-      )
-      , ARRAY[]::text []
-    )) AS config_setting
-  FROM roles AS r
+, current_db AS (
+  SELECT d.oid FROM pg_database AS d WHERE d.datname = current_database()
 )
 
-, parsed_configs AS (
+, overrides AS (
   SELECT
+    drs.setrole AS role_oid
+    , drs.setdatabase AS db_oid
+    , split_part(cfg, '=', 1) AS param_name
+    , substring(cfg FROM position('=' IN cfg) + 1) AS param_value
+  FROM pg_db_role_setting AS drs
+  CROSS JOIN LATERAL unnest(coalesce(drs.setconfig, ARRAY[]::text [])) AS cfg
+  WHERE split_part(cfg, '=', 1) IN (
+    'statement_timeout'
+    , 'idle_in_transaction_session_timeout'
+    , 'transaction_timeout'
+    , 'log_min_duration_statement'
+  )
+)
+
+, candidates AS (
+  SELECT
+    r.rolname
+    , s.name AS setting_name
+    , s.reset_val AS system_default
+    , s.unit
+    , o.param_value AS override_value
+    , CASE
+      WHEN o.role_oid = r.oid AND o.db_oid = cdb.oid THEN 1
+      WHEN o.role_oid = r.oid AND o.db_oid = 0 THEN 2
+      WHEN o.role_oid = 0 AND o.db_oid = cdb.oid THEN 3
+      WHEN o.role_oid = 0 AND o.db_oid = 0 THEN 4
+    END AS priority
+  FROM roles AS r
+  CROSS JOIN settings AS s
+  CROSS JOIN current_db AS cdb
+  LEFT JOIN overrides AS o
+    ON o.param_name = s.name
+    AND (
+      (o.role_oid = r.oid AND o.db_oid = cdb.oid)
+      OR (o.role_oid = r.oid AND o.db_oid = 0)
+      OR (o.role_oid = 0 AND o.db_oid = cdb.oid)
+      OR (o.role_oid = 0 AND o.db_oid = 0)
+    )
+)
+
+, winners AS (
+  SELECT DISTINCT ON (rolname, setting_name)
     rolname
-    , split_part(config_setting, '=', 1) AS param_name
-    , split_part(config_setting, '=', 2) AS param_value
-  FROM role_configs
+    , setting_name
+    , system_default
+    , unit
+    , override_value
+    , priority
+  FROM candidates
+  ORDER BY rolname, setting_name, priority NULLS LAST
 )
 
 SELECT
-  r.rolname::varchar AS role_name
-  , s.name::varchar AS setting_name
-  , s.reset_val AS system_default
-  , s.unit
-  , coalesce(pc.param_value, s.reset_val) AS setting_value
-  , CASE
-    WHEN pc.param_value IS NOT NULL THEN 'OVERRIDE'
+  rolname::varchar AS role_name
+  , setting_name::varchar AS setting_name
+  , system_default
+  , unit
+  , coalesce(override_value, system_default) AS setting_value
+  , CASE priority
+    WHEN 1 THEN 'OVERRIDE_ROLE_DB'
+    WHEN 2 THEN 'OVERRIDE_ROLE'
+    WHEN 3 THEN 'OVERRIDE_DATABASE'
+    WHEN 4 THEN 'OVERRIDE_ALL'
     ELSE 'DEFAULT'
   END AS status
-FROM roles AS r
-CROSS JOIN settings AS s
-LEFT JOIN parsed_configs AS pc
-  ON
-    r.rolname = pc.rolname
-    AND s.name = pc.param_name
-ORDER BY r.rolname, s.name
+FROM winners
+ORDER BY rolname, setting_name
 `
 
 type SessionSettingsRow struct {
@@ -1719,6 +1690,12 @@ type SessionSettingsRow struct {
 	Status        pgtype.Text
 }
 
+// Every pg_db_role_setting entry that could apply, parsed into key/value.
+// Filtered to our inspected settings so the join below stays tiny.
+// substring(... from position('=' in ...) + 1) handles values that contain '='.
+// Cross every role with every setting; LEFT JOIN every candidate override.
+// Each (role, setting) row can produce up to 4 candidate rows; we pick the
+// most-specific one (lowest priority number) via DISTINCT ON below.
 func (q *Queries) SessionSettings(ctx context.Context) ([]SessionSettingsRow, error) {
 	rows, err := q.db.Query(ctx, sessionSettings)
 	if err != nil {

--- a/docs/checks/connection-health.md
+++ b/docs/checks/connection-health.md
@@ -97,8 +97,9 @@ The `connection-efficiency` check shows that connections are well-utilized over 
 Detects when too many connections are idle, indicating an oversized pool.
 
 **Thresholds:**
-- Warning: >50% of connections idle (minimum 20 connections)
-- Critical: >75% of connections idle
+- Warning: ≥90% of connections idle (minimum 20 connections)
+
+Advisory only — a high idle ratio never fails the check. Real connection-exhaustion risk is covered by `connection-saturation` and `pool-pressure`.
 
 **What it means:**
 Many idle connections waste memory and connection slots. This often indicates:

--- a/docs/checks/replication-lag.md
+++ b/docs/checks/replication-lag.md
@@ -64,23 +64,31 @@ Physical replication uses streaming replication protocol where WAL is sent direc
 
 Monitors replay lag for logical replication subscribers (CDC, selective replication, Debezium).
 
-**Severity:**
-- FAIL: >= 35 seconds
-- WARN: >= 20 seconds
-- OK: < 20 seconds
+Severity is the **maximum of two independent tiers** evaluated per slot. A slot is flagged if either tier fires.
 
-**Why much looser than physical?** Logical replication (especially Debezium/CDC) involves:
-- Decoding WAL into logical changes
-- Publishing to external systems (e.g., Kafka)
-- Waiting for Kafka acknowledgments (with `acks=all` replication)
-- Debezium batch processing and LSN flushing (can wait up to 30 seconds)
+#### Tier A — absolute liveness (time AND bytes)
 
-**Debezium-specific behavior:** The Debezium PostgreSQL connector batches changes and flushes LSN positions back to PostgreSQL periodically. During low-activity periods, it can legitimately hold WAL positions for 10-30 seconds before acknowledging consumption. This is normal operation, not a failure.
+Requires **both** a sustained high replay lag **and** a material backlog:
 
-**Thresholds explained:**
-- **< 20s**: Normal operation, including Debezium batch processing
-- **20-35s**: Something may be slow (Kafka backpressure, consumer lag) - investigate
-- **>= 35s**: Consumer is genuinely stuck or misconfigured - requires intervention
+- WARN: replay lag >= 120s **AND** backlog >= 550 MiB
+- FAIL: replay lag >= 300s **AND** backlog >= 2 GiB
+- OK: otherwise
+
+**Why gate on both?** For Debezium/CDC, `replay_lag` time tracks the connector's LSN-ack cadence (batching, Kafka round-trips), not danger. A slot can show high time with a tiny backlog during low-activity periods — that is normal batch behaviour, not a failure. The backlog in bytes is the real risk signal. Requiring both dimensions avoids paging on routine batching while still catching a genuinely growing, stuck slot.
+
+#### Tier B — capacity-relative (backlog vs retention budget)
+
+Active **only when `max_slot_wal_keep_size` is a real cap** (a positive value). On RDS the default is `-1` (unlimited), which **disables this tier** — Tier A is then the only signal.
+
+- WARN: backlog >= 50% of `max_slot_wal_keep_size`
+- FAIL: backlog >= 85% of `max_slot_wal_keep_size`
+- OK: otherwise (or cap is `-1`/unset)
+
+This tier is **independent of time**: a backlog consuming most of the retention budget is dangerous regardless of how long the slot has been lagging.
+
+**Why an early-warning tier?** `wal_status` reflects what Postgres has *already* done to the slot: `reserved`/`extended` mean WAL is still kept, `unreserved` means the slot has exceeded its budget and its WAL is at risk of removal, `lost` means WAL is already gone. Tier B fires at 50-85% of the cap *while `wal_status` is still `reserved`/`extended`* — i.e. **before** the budget is exhausted and the status flips to `unreserved`. The 85% FAIL threshold deliberately sits below 100% to give headroom to act. At 100% the slot flips to `unreserved` and both this check (relative FAIL) and `wal-retention` (FAIL) fire as separate findings of equal severity — reinforcing, not double-counting, so page severity is unchanged.
+
+The fraction is computed in `float64` (`backlog / cap`) to avoid integer overflow at large caps.
 
 ## Lag Metrics Explained
 
@@ -115,7 +123,7 @@ For Debezium and other CDC tools using logical replication, `replay_lag` measure
 
 ### What This Means
 
-When you see "30 seconds of lag" for Debezium, this includes:
+Debezium's reported `replay_lag` time bundles several stages:
 - WAL decoding time (usually <100ms)
 - Kafka publish time (usually <1 second)
 - Kafka acknowledgment time (depends on `acks=all` and replication)
@@ -123,18 +131,21 @@ When you see "30 seconds of lag" for Debezium, this includes:
 
 ### Normal vs Problematic Lag
 
-**Normal Debezium latency:** 1-2 seconds
-- Includes WAL decode + Kafka round-trip with `acks=all`
-- Kafka typically responds in milliseconds to low seconds
+High `replay_lag` **time on its own is normal** for Debezium — it reflects the
+connector's LSN-ack cadence (batching for throughput), not danger. A slot sitting at
+tens of seconds of replay lag with a small backlog is healthy and is intentionally
+reported as OK.
 
-**Problematic lag:** 5+ seconds (your threshold)
-- Indicates actual processing backlog
-- Could be caused by:
-  - High write volume (too many changes to process)
-  - Kafka broker issues (slow responses, replication lag)
-  - Network latency (Debezium to Kafka connection)
-  - Debezium configuration (batch sizes too small)
-  - Downstream consumer lag (backpressure from slow consumers)
+Lag is **problematic** only when it signals an unbounded, growing backlog, which is
+what the `logical-replication-lag` thresholds above capture:
+- **Liveness** — replay lag time stays high *and* the retained backlog is large
+  (≥120s + ≥550 MiB → warn; ≥300s + ≥2 GiB → fail).
+- **Capacity** — the backlog consumes a large fraction of `max_slot_wal_keep_size`
+  (≥50% → warn; ≥85% → fail), when a cap is set. This is the early signal before
+  `wal_status` flips to `unreserved`.
+
+A growing backlog is usually caused by a stuck or slow consumer: Kafka broker issues,
+network problems, too-small Debezium batch sizes, or downstream backpressure.
 
 ### Diagnosing High Debezium Lag
 

--- a/docs/checks/session-settings.md
+++ b/docs/checks/session-settings.md
@@ -11,6 +11,25 @@ By default, application roles are **discovered dynamically** — any login-capab
 - **idle_in_transaction_session_timeout**: Timeout for idle transactions
 - **log_min_duration_statement**: Threshold for logging slow queries
 
+## Precedence model
+
+For each `(role, setting)` pair, the check resolves the value the role would actually see when it connects to the current database, walking the PostgreSQL GUC hierarchy from most-specific to least-specific:
+
+| Priority | Source                                              | `pg_db_role_setting` row              |
+|----------|-----------------------------------------------------|---------------------------------------|
+| 1        | `ALTER ROLE r IN DATABASE d SET ...`                | `setrole=r.oid`, `setdatabase=d.oid`  |
+| 2        | `ALTER ROLE r SET ...`                              | `setrole=r.oid`, `setdatabase=0`      |
+| 3        | `ALTER DATABASE d SET ...` / `ALTER ROLE ALL IN DATABASE d SET ...` | `setrole=0`, `setdatabase=d.oid` |
+| 4        | `ALTER ROLE ALL SET ...`                            | `setrole=0`, `setdatabase=0`          |
+| 5        | Cluster default (`postgresql.conf` / `ALTER SYSTEM` / built-in) | `pg_settings.reset_val` fallback |
+
+The `status` column in the SQL result reports which level the value came from (`OVERRIDE_ROLE_DB`, `OVERRIDE_ROLE`, `OVERRIDE_DATABASE`, `OVERRIDE_ALL`, `DEFAULT`) so the origin of any value is debuggable from the raw query.
+
+### Caveats
+
+- Level-5 fallback uses `pg_settings.reset_val`, which reflects what the *connecting* session would receive on `RESET` — including any `ALTER ROLE` overrides on the role pgdoctor itself connects as. To keep that fallback accurate for other roles, **run pgdoctor as a role with no overrides on the inspected settings**.
+- Switching the cluster-default fallback to `pg_file_settings` + `boot_val` is a planned follow-up. It removes the caveat above but requires granting pgdoctor membership in the `pg_read_all_settings` predefined role, which is why it's intentionally out of scope for this check today.
+
 ## Why it matters
 
 Proper session settings prevent critical production issues:


### PR DESCRIPTION
Reduces false positives and fixes correctness across three checks. **All queries remain PostgreSQL 14+ compatible** (verified against a live `postgres:14`; `transaction_timeout` / `max_slot_wal_keep_size` handled gracefully across versions).

## session-settings (correctness)
- **Precedence**: encode the full `pg_db_role_setting` precedence — `role+db > role > db > ALTER ROLE ALL > reset_val` — instead of only catching cluster-wide role overrides. The reported value now matches what a role actually gets on connect. (Note: role-wide overrides database-wide, per the PG docs.)
- **Unit parsing**: `ALTER ROLE ... SET statement_timeout='2000ms'` stores the value literally, so the old `strconv.ParseInt` crashed and skipped the whole check. New unit-aware parser handles `2000ms`, `2s`, `1min`, `1.5s`, bare numbers, and `-1`/`0` sentinels → milliseconds.
- **Version gating**: `transaction_timeout` is PG17+. On PG<17 it is absent from `pg_settings`, so the check now **skips** it instead of reporting a false `MUST be set` FAIL for every role.

## connection-health / idle-ratio (noise)
- Now **advisory**: warn at `>=90%` idle, **no FAIL tier**. A high idle ratio is a harmless oversized-pool hint; genuine connection exhaustion is already covered by `connection-saturation` and `pool-pressure`.

## replication-lag — logical (noise + capacity awareness)
- `replay_lag` time tracks Debezium's LSN-ack cadence (batching), not danger. WARN/FAIL now require **both** sustained time **and** a material backlog: `>=120s + >=550 MiB` (warn), `>=300s + >=2 GiB` (fail).
- New **capacity-relative** signal: compares the backlog against `max_slot_wal_keep_size` (`>=50%` warn, `>=85%` fail), firing **before** Postgres flips `wal_status` to `unreserved`. Disabled when the cap is `-1` (unlimited / RDS default).
- Severity = the max of the two tiers. Physical replication unchanged.

## Notes
- `db/query.sql.go` is regenerated; this also drops the orphan `MissingProviderIdTables` (no source query/check exists for it).
- Tests cover the parser edge cases, the version-gated skip, the idle-ratio downgrade, and the logical-lag tiers (incl. real production samples that should stay OK).