### PR TITLE
fix(cli): render Finding.Debug for single-finding checks under --detail debug

### DIFF
--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -89,6 +89,11 @@ func printCheckReport(w io.Writer, report *check.Report, opts *runOptions) {
 			fmt.Fprintln(w)
 			printTable(w, result.Table, 2, opts)
 		}
+		if opts.detail == string(detailDebug) && result.Debug != "" {
+			fmt.Fprintln(w)
+			fmt.Fprintln(w, "  Debug:")
+			fmt.Fprintf(w, "%s\n", indent(result.Debug, 4))
+		}
 	} else {
 		fmt.Fprintf(w, "%s %s %s%s\n",
 			colorFunc(fmt.Sprintf("[%s]", label)),

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/emancu/pgdoctor/check"
+	"github.com/stretchr/testify/assert"
+)
+
+// singleFindingReport builds a report whose only finding has ID == CheckID,
+// which routes printCheckReport through the header-folded single-finding branch.
+func singleFindingReport() *check.Report {
+	report := check.NewReport(check.Metadata{CheckID: "demo", Name: "Demo Check"})
+	report.AddFinding(check.Finding{
+		ID:       "demo",
+		Name:     "Demo Check",
+		Severity: check.SeverityWarn,
+		Details:  "something looks off",
+		Debug:    "SELECT 1 -- debug payload",
+	})
+	return report
+}
+
+func TestPrintCheckReport_SingleFinding_ShowsDebugUnderDebugDetail(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	printCheckReport(&buf, singleFindingReport(), &runOptions{detail: string(detailDebug)})
+
+	out := buf.String()
+	assert.Contains(t, out, "Debug:", "single-finding debug block must render under --detail debug")
+	assert.Contains(t, out, "SELECT 1 -- debug payload")
+}
+
+func TestPrintCheckReport_SingleFinding_HidesDebugWithoutDebugDetail(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	printCheckReport(&buf, singleFindingReport(), &runOptions{detail: string(detailBrief)})
+
+	assert.NotContains(t, buf.String(), "Debug:", "debug must stay hidden unless --detail debug")
+}


### PR DESCRIPTION
Fixes #9.

The `singleFinding` branch of `printCheckReport` (`internal/cli/output.go`) handled `Details` and `Table` but **dropped `result.Debug`** — so for any check whose only finding has `ID == report.CheckID`, debug output was silently lost even with `--detail debug`. The multi-finding path (`printSubcheck`) already renders it; this mirrors the exact same block.

```go
if opts.detail == string(detailDebug) && result.Debug != "" {
    fmt.Fprintln(w)
    fmt.Fprintln(w, "  Debug:")
    fmt.Fprintf(w, "%s\n", indent(result.Debug, 4))
}
```

### Assessment
- **Real but latent upstream:** no check currently populates `Finding.Debug`, so nothing is dropped *today* — but the asymmetry bites the moment one does (and it's already fixed in Houston's downstream renderer).
- **Zero behaviour change otherwise:** only adds output under `--detail debug` when `Debug != ""`.

### Tests
Adds `internal/cli/output_test.go` (first coverage for that file): asserts the single-finding debug block renders under `--detail debug` and stays hidden otherwise.