### PR TITLE
fix(checks): invalidindexes — exclude in-flight builds, classify REINDEX leftovers

### DIFF
--- a/checks/invalidindexes/README.md
+++ b/checks/invalidindexes/README.md
@@ -1,107 +1,45 @@
 # Invalid Indexes Check
 
-Identifies PostgreSQL indexes that are in an invalid state (`pg_index.indisvalid = false`)
-and not used by the query planner — while ignoring indexes that are merely being
-built right now.
+Finds indexes stuck in an invalid state (`pg_index.indisvalid = false`). The
+planner ignores them, so they cost disk without helping queries.
 
 ## What it checks
 
-An index ends up `indisvalid = false` for one of three reasons, and this check
-treats each differently:
+Reports each invalid index as **WARN**, classified by `Type`:
 
-1. **In-flight build (silently ignored).** While a `CREATE INDEX CONCURRENTLY` or
-   `REINDEX INDEX CONCURRENTLY` is running, the new index is invalid until the
-   build completes. The check excludes any index that has an active
-   `pg_stat_progress_create_index` row, because it is in flight, not broken.
+- **broken** — a `CREATE INDEX CONCURRENTLY` that failed or was interrupted, or
+  any other permanently-invalid index.
+- **leftover** — a `_ccnew`/`_ccold` transient left behind by a failed or
+  cancelled `REINDEX CONCURRENTLY`. The original index is still valid.
 
-2. **Broken index → FAIL.** A genuinely-broken index (`is_leftover = false`): a
-   `CREATE INDEX CONCURRENTLY` that failed or was interrupted, leaving a permanent
-   invalid index that the planner ignores. Reported under the `broken-indexes`
-   subcheck as **FAIL** when any exist.
+Indexes a `CREATE`/`REINDEX INDEX CONCURRENTLY` is *currently* building are
+excluded — they are invalid only until the build finishes (in flight, not
+broken). System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are
+excluded; `cron`/`pgpartman`/`debezium` are not, since an invalid index there is
+a real problem.
 
-3. **Abandoned REINDEX leftover → WARN.** A `_ccnew`/`_ccold` transient
-   (`is_leftover = true`) left behind by a failed or cancelled
-   `REINDEX CONCURRENTLY`. The original index is still valid, so these are
-   non-urgent clutter. Reported under the `abandoned-leftovers` subcheck as
-   **WARN** when any exist.
-
-Both subchecks are always emitted: each reports `OK` when its class is empty.
-The overall check severity is the maximum across the two findings.
-
-System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are excluded. An
-invalid index in `cron`/`pgpartman`/`debezium` is intentionally *not* excluded —
-unlike a duplicate index, an invalid index there is a real operational problem.
-
-## Why it matters
-
-Invalid indexes cause problems:
-
-- **Wasted disk space**: Invalid indexes consume storage but provide no benefit
-- **Query performance**: Not used by the query planner, defeating their purpose
-- **Hidden failures**: May indicate underlying data quality or operational issues
-- **Confusion**: Can mislead developers during query optimization
-
-## How to Fix
-
-### Broken indexes (FAIL)
-
-For each broken index, choose one of:
-
-**Rebuild the index** (preferred when the index is still wanted):
+## How to fix
 
 ```sql
-REINDEX INDEX CONCURRENTLY your_schema.your_index_name;
+-- broken: rebuild, or drop if the index is no longer wanted
+REINDEX INDEX CONCURRENTLY your_schema.your_index;
+DROP INDEX CONCURRENTLY your_schema.your_index;
+
+-- leftover: just drop it, the original index is still valid
+DROP INDEX CONCURRENTLY your_schema.your_leftover;
 ```
 
-**Drop the index** (if it is no longer needed):
+For a broken index, check the PostgreSQL logs for the original failure before
+rebuilding.
 
-```sql
-DROP INDEX CONCURRENTLY your_schema.your_index_name;
-```
+## Notes
 
-Before rebuilding:
-
-1. Investigate why the index failed initially
-2. Check for locking issues or timeout problems
-3. Verify the underlying data satisfies the index conditions
-4. Consider if the index definition needs modification
-
-### Abandoned REINDEX leftovers (WARN)
-
-The original index is still valid; the `_ccnew`/`_ccold` leftover can simply be
-dropped:
-
-```sql
-DROP INDEX CONCURRENTLY your_schema.your_leftover_index;
-```
-
-### Investigation Steps
-
-1. **Check index definition:**
-   ```sql
-   SELECT indexdef FROM pg_indexes WHERE indexname = 'your_index_name';
-   ```
-2. **Review PostgreSQL logs** for errors during index creation
-3. **Verify data integrity** — ensure data meets index constraints
-4. **Check for lock conflicts** that might have interrupted creation
-
-## Notes / caveats
-
-- **Read replicas.** On a standby, an in-flight build on the primary can briefly
-  surface its `_ccnew` index as a WARN: the standby sees the invalid index but
-  `pg_stat_progress_create_index` reflects only local backends, so the in-flight
-  exclusion does not apply. It clears once the primary finishes and the change
-  replays.
-- **Naming collisions.** A user index literally named `*_ccnew`/`*_ccold` that is
-  genuinely invalid would be classified as a WARN leftover rather than a FAIL.
-  This is rare and only affects severity, not detection.
-- **Classification can change between runs.** Whether a given `_ccnew` index is
-  reported (and as what) can change from one run to the next as a concurrent
-  reindex makes progress, completes, or its backend dies and leaves the transient
-  behind.
+- On a read replica, an in-flight build on the primary can briefly show its
+  `_ccnew` as a leftover (`pg_stat_progress_create_index` is local-only); it
+  clears once the build replays.
+- A user index literally named `*_ccnew`/`*_ccold` would be labelled `leftover`.
 
 ## References
 
-- [PostgreSQL Documentation: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
-- [PostgreSQL Documentation: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
-- [PostgreSQL Documentation: pg_stat_progress_create_index](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING)
+- [CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
+- [REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)

--- a/checks/invalidindexes/README.md
+++ b/checks/invalidindexes/README.md
@@ -1,45 +1,74 @@
-# Invalid Indexes Check
+# Invalid Indexes
 
-Finds indexes stuck in an invalid state (`pg_index.indisvalid = false`). The
-planner ignores them, so they cost disk without helping queries.
+Identifies indexes left in an invalid state (`pg_index.indisvalid = false`). The planner ignores invalid indexes, so they cost disk and maintenance without serving any query.
 
-## What it checks
+## What It Checks
 
-Reports each invalid index as **WARN**, classified by `Type`:
+Every invalid index is reported as **WARN** and tagged with a `Type` so you know how to act on it. Indexes a concurrent build is *currently* working on are excluded — they are invalid only until the build finishes.
 
-- **broken** — a `CREATE INDEX CONCURRENTLY` that failed or was interrupted, or
-  any other permanently-invalid index.
-- **leftover** — a `_ccnew`/`_ccold` transient left behind by a failed or
-  cancelled `REINDEX CONCURRENTLY`. The original index is still valid.
+### Broken (`broken`)
+A permanently-invalid index: a `CREATE INDEX CONCURRENTLY` that failed or was interrupted, or any other index PostgreSQL has marked invalid.
 
-Indexes a `CREATE`/`REINDEX INDEX CONCURRENTLY` is *currently* building are
-excluded — they are invalid only until the build finishes (in flight, not
-broken). System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are
-excluded; `cron`/`pgpartman`/`debezium` are not, since an invalid index there is
-a real problem.
+**Severity**: WARN
 
-## How to fix
+**Example**:
+```sql
+CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
+-- interrupted or failed -> idx_users_email stays indisvalid = false
+```
+
+### Abandoned REINDEX leftover (`leftover`)
+A `_ccnew`/`_ccold` transient left behind by a failed or cancelled `REINDEX INDEX CONCURRENTLY`. The original index is still valid and in use, so the leftover is harmless clutter.
+
+**Severity**: WARN
+
+**Example**:
+```sql
+REINDEX INDEX CONCURRENTLY idx_orders_status;
+-- cancelled mid-build -> idx_orders_status_ccnew left behind, invalid
+```
+
+### Excluded: builds in flight
+While a `CREATE INDEX CONCURRENTLY` or `REINDEX INDEX CONCURRENTLY` is running, the new index is invalid until the build completes. These have an active `pg_stat_progress_create_index` row and are excluded — in flight, not broken.
+
+System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are excluded. Unlike duplicate indexes, an invalid index in `cron`/`pgpartman`/`debezium` *is* reported — there, it is a real operational problem.
+
+## Why It Matters
+
+Invalid indexes cause problems:
+
+- **Wasted disk space**: they consume storage but provide no benefit
+- **Query performance**: the planner ignores them, defeating their purpose
+- **Hidden failures**: often a sign of an interrupted migration or operational issue
+- **Confusion**: can mislead developers during query optimization
+
+## How to Fix
+
+### Broken indexes
+Rebuild it (preferred if the index is still wanted) or drop it:
 
 ```sql
--- broken: rebuild, or drop if the index is no longer wanted
 REINDEX INDEX CONCURRENTLY your_schema.your_index;
+-- or, if it is no longer needed:
 DROP INDEX CONCURRENTLY your_schema.your_index;
+```
 
--- leftover: just drop it, the original index is still valid
+Check the PostgreSQL logs for the original failure before rebuilding.
+
+### Abandoned leftovers
+The original index is still valid — just drop the leftover:
+
+```sql
 DROP INDEX CONCURRENTLY your_schema.your_leftover;
 ```
 
-For a broken index, check the PostgreSQL logs for the original failure before
-rebuilding.
+## Important Considerations
 
-## Notes
-
-- On a read replica, an in-flight build on the primary can briefly show its
-  `_ccnew` as a leftover (`pg_stat_progress_create_index` is local-only); it
-  clears once the build replays.
-- A user index literally named `*_ccnew`/`*_ccold` would be labelled `leftover`.
+- **Read replicas**: on a standby, an in-flight build on the primary can briefly show its `_ccnew` as a `leftover` — `pg_stat_progress_create_index` reflects local backends only. It clears once the build replays.
+- **Naming collisions**: a user index literally named `*_ccnew`/`*_ccold` that is genuinely invalid would be tagged `leftover` rather than `broken`. Rare, and only affects the label.
 
 ## References
 
-- [CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
-- [REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
+- [PostgreSQL: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
+- [PostgreSQL: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
+- [PostgreSQL: pg_stat_progress_create_index](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING)

--- a/checks/invalidindexes/README.md
+++ b/checks/invalidindexes/README.md
@@ -1,48 +1,78 @@
 # Invalid Indexes Check
 
-Identifies PostgreSQL indexes that are in an invalid state and not being used by the query planner.
+Identifies PostgreSQL indexes that are in an invalid state (`pg_index.indisvalid = false`)
+and not used by the query planner — while ignoring indexes that are merely being
+built right now.
 
 ## What it checks
 
-- Indexes marked as invalid in `pg_index.indisvalid`
-- Indexes that failed during concurrent creation or reindexing
-- Orphaned invalid indexes taking up disk space
+An index ends up `indisvalid = false` for one of three reasons, and this check
+treats each differently:
+
+1. **In-flight build (silently ignored).** While a `CREATE INDEX CONCURRENTLY` or
+   `REINDEX INDEX CONCURRENTLY` is running, the new index is invalid until the
+   build completes. The check excludes any index that has an active
+   `pg_stat_progress_create_index` row, because it is in flight, not broken.
+
+2. **Broken index → FAIL.** A genuinely-broken index (`is_leftover = false`): a
+   `CREATE INDEX CONCURRENTLY` that failed or was interrupted, leaving a permanent
+   invalid index that the planner ignores. Reported under the `broken-indexes`
+   subcheck as **FAIL** when any exist.
+
+3. **Abandoned REINDEX leftover → WARN.** A `_ccnew`/`_ccold` transient
+   (`is_leftover = true`) left behind by a failed or cancelled
+   `REINDEX CONCURRENTLY`. The original index is still valid, so these are
+   non-urgent clutter. Reported under the `abandoned-leftovers` subcheck as
+   **WARN** when any exist.
+
+Both subchecks are always emitted: each reports `OK` when its class is empty.
+The overall check severity is the maximum across the two findings.
+
+System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are excluded. An
+invalid index in `cron`/`pgpartman`/`debezium` is intentionally *not* excluded —
+unlike a duplicate index, an invalid index there is a real operational problem.
 
 ## Why it matters
 
 Invalid indexes cause problems:
+
 - **Wasted disk space**: Invalid indexes consume storage but provide no benefit
 - **Query performance**: Not used by the query planner, defeating their purpose
 - **Hidden failures**: May indicate underlying data quality or operational issues
 - **Confusion**: Can mislead developers during query optimization
 
-An index becomes invalid when:
-- `CREATE INDEX CONCURRENTLY` fails or is interrupted
-- `REINDEX CONCURRENTLY` encounters an error
-- Data doesn't satisfy the index conditions
-
 ## How to Fix
 
-For each invalid index, choose one of these options:
+### Broken indexes (FAIL)
 
-### Option 1: Recreate the Index
+For each broken index, choose one of:
+
+**Rebuild the index** (preferred when the index is still wanted):
 
 ```sql
-REINDEX INDEX CONCURRENTLY your_index_name;
+REINDEX INDEX CONCURRENTLY your_schema.your_index_name;
 ```
 
-**Before recreating:**
+**Drop the index** (if it is no longer needed):
+
+```sql
+DROP INDEX CONCURRENTLY your_schema.your_index_name;
+```
+
+Before rebuilding:
+
 1. Investigate why the index failed initially
 2. Check for locking issues or timeout problems
 3. Verify the underlying data satisfies the index conditions
 4. Consider if the index definition needs modification
 
-### Option 2: Drop the Index
+### Abandoned REINDEX leftovers (WARN)
 
-If the index is no longer needed:
+The original index is still valid; the `_ccnew`/`_ccold` leftover can simply be
+dropped:
 
 ```sql
-DROP INDEX CONCURRENTLY your_index_name;
+DROP INDEX CONCURRENTLY your_schema.your_leftover_index;
 ```
 
 ### Investigation Steps
@@ -51,14 +81,27 @@ DROP INDEX CONCURRENTLY your_index_name;
    ```sql
    SELECT indexdef FROM pg_indexes WHERE indexname = 'your_index_name';
    ```
-
 2. **Review PostgreSQL logs** for errors during index creation
-
-3. **Verify data integrity** - ensure data meets index constraints
-
+3. **Verify data integrity** — ensure data meets index constraints
 4. **Check for lock conflicts** that might have interrupted creation
+
+## Notes / caveats
+
+- **Read replicas.** On a standby, an in-flight build on the primary can briefly
+  surface its `_ccnew` index as a WARN: the standby sees the invalid index but
+  `pg_stat_progress_create_index` reflects only local backends, so the in-flight
+  exclusion does not apply. It clears once the primary finishes and the change
+  replays.
+- **Naming collisions.** A user index literally named `*_ccnew`/`*_ccold` that is
+  genuinely invalid would be classified as a WARN leftover rather than a FAIL.
+  This is rare and only affects severity, not detection.
+- **Classification can change between runs.** Whether a given `_ccnew` index is
+  reported (and as what) can change from one run to the next as a concurrent
+  reindex makes progress, completes, or its backend dies and leaves the transient
+  behind.
 
 ## References
 
 - [PostgreSQL Documentation: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
 - [PostgreSQL Documentation: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
+- [PostgreSQL Documentation: pg_stat_progress_create_index](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING)

--- a/checks/invalidindexes/README.md
+++ b/checks/invalidindexes/README.md
@@ -1,74 +1,67 @@
-# Invalid Indexes
+# Invalid Indexes Check
 
-Identifies indexes left in an invalid state (`pg_index.indisvalid = false`). The planner ignores invalid indexes, so they cost disk and maintenance without serving any query.
+Identifies PostgreSQL indexes that are in an invalid state and not being used by the query planner.
 
-## What It Checks
+## What it checks
 
-Every invalid index is reported as **WARN** and tagged with a `Type` so you know how to act on it. Indexes a concurrent build is *currently* working on are excluded — they are invalid only until the build finishes.
+- Indexes marked as invalid in `pg_index.indisvalid`
+- Indexes that failed during concurrent creation or reindexing
+- Orphaned invalid indexes taking up disk space
+- Abandoned `_ccnew`/`_ccold` leftovers from a cancelled `REINDEX CONCURRENTLY` (tagged `leftover` — safe to drop)
 
-### Broken (`broken`)
-A permanently-invalid index: a `CREATE INDEX CONCURRENTLY` that failed or was interrupted, or any other index PostgreSQL has marked invalid.
+Indexes a live `CREATE`/`REINDEX INDEX CONCURRENTLY` is still building are excluded — they are invalid only until the build finishes.
 
-**Severity**: WARN
-
-**Example**:
-```sql
-CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
--- interrupted or failed -> idx_users_email stays indisvalid = false
-```
-
-### Abandoned REINDEX leftover (`leftover`)
-A `_ccnew`/`_ccold` transient left behind by a failed or cancelled `REINDEX INDEX CONCURRENTLY`. The original index is still valid and in use, so the leftover is harmless clutter.
-
-**Severity**: WARN
-
-**Example**:
-```sql
-REINDEX INDEX CONCURRENTLY idx_orders_status;
--- cancelled mid-build -> idx_orders_status_ccnew left behind, invalid
-```
-
-### Excluded: builds in flight
-While a `CREATE INDEX CONCURRENTLY` or `REINDEX INDEX CONCURRENTLY` is running, the new index is invalid until the build completes. These have an active `pg_stat_progress_create_index` row and are excluded — in flight, not broken.
-
-System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are excluded. Unlike duplicate indexes, an invalid index in `cron`/`pgpartman`/`debezium` *is* reported — there, it is a real operational problem.
-
-## Why It Matters
+## Why it matters
 
 Invalid indexes cause problems:
+- **Wasted disk space**: Invalid indexes consume storage but provide no benefit
+- **Query performance**: Not used by the query planner, defeating their purpose
+- **Hidden failures**: May indicate underlying data quality or operational issues
+- **Confusion**: Can mislead developers during query optimization
 
-- **Wasted disk space**: they consume storage but provide no benefit
-- **Query performance**: the planner ignores them, defeating their purpose
-- **Hidden failures**: often a sign of an interrupted migration or operational issue
-- **Confusion**: can mislead developers during query optimization
+An index becomes invalid when:
+- `CREATE INDEX CONCURRENTLY` fails or is interrupted
+- `REINDEX CONCURRENTLY` encounters an error
+- Data doesn't satisfy the index conditions
 
 ## How to Fix
 
-### Broken indexes
-Rebuild it (preferred if the index is still wanted) or drop it:
+For each invalid index, choose one of these options:
+
+### Option 1: Recreate the Index
 
 ```sql
-REINDEX INDEX CONCURRENTLY your_schema.your_index;
--- or, if it is no longer needed:
-DROP INDEX CONCURRENTLY your_schema.your_index;
+REINDEX INDEX CONCURRENTLY your_index_name;
 ```
 
-Check the PostgreSQL logs for the original failure before rebuilding.
+**Before recreating:**
+1. Investigate why the index failed initially
+2. Check for locking issues or timeout problems
+3. Verify the underlying data satisfies the index conditions
+4. Consider if the index definition needs modification
 
-### Abandoned leftovers
-The original index is still valid — just drop the leftover:
+### Option 2: Drop the Index
+
+If the index is no longer needed:
 
 ```sql
-DROP INDEX CONCURRENTLY your_schema.your_leftover;
+DROP INDEX CONCURRENTLY your_index_name;
 ```
 
-## Important Considerations
+### Investigation Steps
 
-- **Read replicas**: on a standby, an in-flight build on the primary can briefly show its `_ccnew` as a `leftover` — `pg_stat_progress_create_index` reflects local backends only. It clears once the build replays.
-- **Naming collisions**: a user index literally named `*_ccnew`/`*_ccold` that is genuinely invalid would be tagged `leftover` rather than `broken`. Rare, and only affects the label.
+1. **Check index definition:**
+   ```sql
+   SELECT indexdef FROM pg_indexes WHERE indexname = 'your_index_name';
+   ```
+
+2. **Review PostgreSQL logs** for errors during index creation
+
+3. **Verify data integrity** - ensure data meets index constraints
+
+4. **Check for lock conflicts** that might have interrupted creation
 
 ## References
 
-- [PostgreSQL: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
-- [PostgreSQL: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
-- [PostgreSQL: pg_stat_progress_create_index](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING)
+- [PostgreSQL Documentation: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
+- [PostgreSQL Documentation: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)

--- a/checks/invalidindexes/check.go
+++ b/checks/invalidindexes/check.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"strings"
 
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/db"
@@ -49,31 +48,106 @@ func (c *checker) Metadata() check.Metadata {
 func (c *checker) Check(ctx context.Context) (*check.Report, error) {
 	report := check.NewReport(Metadata())
 
-	invalidIndexes, err := c.queries.BrokenIndexes(ctx)
+	rows, err := c.queries.BrokenIndexes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("running %s/%s: %w", check.CategoryIndexes, report.CheckID, err)
 	}
 
-	if len(invalidIndexes) == 0 {
-		report.AddFinding(check.Finding{
-			ID:       report.CheckID,
-			Name:     report.Name,
-			Severity: check.SeverityOK,
-		})
-		return report, nil
+	var broken, leftovers []db.BrokenIndexesRow
+	for _, row := range rows {
+		if row.IsLeftover {
+			leftovers = append(leftovers, row)
+		} else {
+			broken = append(broken, row)
+		}
 	}
 
-	lines := []string{}
-	for _, index := range invalidIndexes {
-		lines = append(lines, fmt.Sprintf("%s\t%s", index.TableName, index.IndexName))
+	addBrokenFinding(report, broken)
+	addLeftoverFinding(report, leftovers)
+
+	return report, nil
+}
+
+// addBrokenFinding reports genuinely-broken indexes (is_leftover = false).
+// These are urgent: an invalid index is dead weight the planner ignores, so it
+// is a FAIL when any exist.
+func addBrokenFinding(report *check.Report, rows []db.BrokenIndexesRow) {
+	if len(rows) == 0 {
+		report.AddFinding(check.Finding{
+			ID:       "broken-indexes",
+			Name:     "Broken Indexes",
+			Severity: check.SeverityOK,
+			Details:  "No broken indexes found",
+		})
+		return
 	}
 
 	report.AddFinding(check.Finding{
-		ID:       report.CheckID,
-		Name:     report.Name,
-		Severity: check.SeverityWarn,
-		Details:  fmt.Sprintf("There are %d invalid indexes.\n%s\n", len(invalidIndexes), strings.Join(lines, "\n")),
+		ID:       "broken-indexes",
+		Name:     "Broken Indexes",
+		Severity: check.SeverityFail,
+		Details: fmt.Sprintf(
+			"Found %s. Rebuild with REINDEX INDEX CONCURRENTLY <schema>.<index>; "+
+				"or remove with DROP INDEX CONCURRENTLY <schema>.<index>;.",
+			pluralIndexes(len(rows)),
+		),
+		Table: indexTable(rows, check.SeverityFail),
 	})
+}
 
-	return report, nil
+// addLeftoverFinding reports abandoned REINDEX CONCURRENTLY transients
+// (_ccnew/_ccold, is_leftover = true). The original index is still valid, so
+// these are non-urgent clutter: a WARN when any exist.
+func addLeftoverFinding(report *check.Report, rows []db.BrokenIndexesRow) {
+	if len(rows) == 0 {
+		report.AddFinding(check.Finding{
+			ID:       "abandoned-leftovers",
+			Name:     "Abandoned REINDEX Leftovers",
+			Severity: check.SeverityOK,
+			Details:  "No abandoned REINDEX CONCURRENTLY leftovers found",
+		})
+		return
+	}
+
+	report.AddFinding(check.Finding{
+		ID:       "abandoned-leftovers",
+		Name:     "Abandoned REINDEX Leftovers",
+		Severity: check.SeverityWarn,
+		Details: fmt.Sprintf(
+			"Found %s left behind by a failed or cancelled REINDEX CONCURRENTLY. "+
+				"The original index is still valid; drop the leftover with "+
+				"DROP INDEX CONCURRENTLY <schema>.<index>;.",
+			pluralLeftovers(len(rows)),
+		),
+		Table: indexTable(rows, check.SeverityWarn),
+	})
+}
+
+func indexTable(rows []db.BrokenIndexesRow, severity check.Severity) *check.Table {
+	tableRows := make([]check.TableRow, 0, len(rows))
+	for _, row := range rows {
+		tableRows = append(tableRows, check.TableRow{
+			Cells:    []string{row.SchemaName, row.TableName, row.IndexName},
+			Severity: severity,
+		})
+	}
+
+	return &check.Table{
+		Headers: []string{"Schema", "Table", "Index"},
+		Rows:    tableRows,
+	}
+}
+
+func pluralIndexes(n int) string {
+	if n == 1 {
+		return "1 broken index"
+	}
+	return fmt.Sprintf("%d broken indexes", n)
+}
+
+func pluralLeftovers(n int) string {
+	if n == 1 {
+		return "1 abandoned leftover index"
+	}
+	return fmt.Sprintf("%d abandoned leftover indexes", n)
 }

--- a/checks/invalidindexes/check.go
+++ b/checks/invalidindexes/check.go
@@ -53,101 +53,52 @@ func (c *checker) Check(ctx context.Context) (*check.Report, error) {
 		return nil, fmt.Errorf("running %s/%s: %w", check.CategoryIndexes, report.CheckID, err)
 	}
 
-	var broken, leftovers []db.BrokenIndexesRow
-	for _, row := range rows {
-		if row.IsLeftover {
-			leftovers = append(leftovers, row)
-		} else {
-			broken = append(broken, row)
-		}
+	if len(rows) == 0 {
+		report.AddFinding(check.Finding{
+			ID:       report.CheckID,
+			Name:     report.Name,
+			Severity: check.SeverityOK,
+		})
+		return report, nil
 	}
 
-	addBrokenFinding(report, broken)
-	addLeftoverFinding(report, leftovers)
+	// One finding, all WARN: a broken index and an abandoned _ccnew/_ccold
+	// leftover are both "clean this up" work, not a 3am page. The Type column
+	// preserves the distinction; the fix for each lives in the README and
+	// `explain` output rather than inline, to keep the run summary terse.
+	var broken, leftover int
+	tableRows := make([]check.TableRow, 0, len(rows))
+	for _, row := range rows {
+		kind := "broken"
+		if row.IsLeftover {
+			kind = "leftover"
+			leftover++
+		} else {
+			broken++
+		}
+		tableRows = append(tableRows, check.TableRow{
+			Cells:    []string{row.SchemaName, row.TableName, row.IndexName, kind},
+			Severity: check.SeverityWarn,
+		})
+	}
+
+	report.AddFinding(check.Finding{
+		ID:       report.CheckID,
+		Name:     report.Name,
+		Severity: check.SeverityWarn,
+		Details:  fmt.Sprintf("%s (%d broken, %d leftover)", pluralIndexes(len(rows)), broken, leftover),
+		Table: &check.Table{
+			Headers: []string{"Schema", "Table", "Index", "Type"},
+			Rows:    tableRows,
+		},
+	})
 
 	return report, nil
 }
 
-// addBrokenFinding reports genuinely-broken indexes (is_leftover = false).
-// These are urgent: an invalid index is dead weight the planner ignores, so it
-// is a FAIL when any exist.
-func addBrokenFinding(report *check.Report, rows []db.BrokenIndexesRow) {
-	if len(rows) == 0 {
-		report.AddFinding(check.Finding{
-			ID:       "broken-indexes",
-			Name:     "Broken Indexes",
-			Severity: check.SeverityOK,
-			Details:  "No broken indexes found",
-		})
-		return
-	}
-
-	report.AddFinding(check.Finding{
-		ID:       "broken-indexes",
-		Name:     "Broken Indexes",
-		Severity: check.SeverityFail,
-		Details: fmt.Sprintf(
-			"Found %s. Rebuild with REINDEX INDEX CONCURRENTLY <schema>.<index>; "+
-				"or remove with DROP INDEX CONCURRENTLY <schema>.<index>;.",
-			pluralIndexes(len(rows)),
-		),
-		Table: indexTable(rows, check.SeverityFail),
-	})
-}
-
-// addLeftoverFinding reports abandoned REINDEX CONCURRENTLY transients
-// (_ccnew/_ccold, is_leftover = true). The original index is still valid, so
-// these are non-urgent clutter: a WARN when any exist.
-func addLeftoverFinding(report *check.Report, rows []db.BrokenIndexesRow) {
-	if len(rows) == 0 {
-		report.AddFinding(check.Finding{
-			ID:       "abandoned-leftovers",
-			Name:     "Abandoned REINDEX Leftovers",
-			Severity: check.SeverityOK,
-			Details:  "No abandoned REINDEX CONCURRENTLY leftovers found",
-		})
-		return
-	}
-
-	report.AddFinding(check.Finding{
-		ID:       "abandoned-leftovers",
-		Name:     "Abandoned REINDEX Leftovers",
-		Severity: check.SeverityWarn,
-		Details: fmt.Sprintf(
-			"Found %s left behind by a failed or cancelled REINDEX CONCURRENTLY. "+
-				"The original index is still valid; drop the leftover with "+
-				"DROP INDEX CONCURRENTLY <schema>.<index>;.",
-			pluralLeftovers(len(rows)),
-		),
-		Table: indexTable(rows, check.SeverityWarn),
-	})
-}
-
-func indexTable(rows []db.BrokenIndexesRow, severity check.Severity) *check.Table {
-	tableRows := make([]check.TableRow, 0, len(rows))
-	for _, row := range rows {
-		tableRows = append(tableRows, check.TableRow{
-			Cells:    []string{row.SchemaName, row.TableName, row.IndexName},
-			Severity: severity,
-		})
-	}
-
-	return &check.Table{
-		Headers: []string{"Schema", "Table", "Index"},
-		Rows:    tableRows,
-	}
-}
-
 func pluralIndexes(n int) string {
 	if n == 1 {
-		return "1 broken index"
+		return "1 invalid index"
 	}
-	return fmt.Sprintf("%d broken indexes", n)
-}
-
-func pluralLeftovers(n int) string {
-	if n == 1 {
-		return "1 abandoned leftover index"
-	}
-	return fmt.Sprintf("%d abandoned leftover indexes", n)
+	return fmt.Sprintf("%d invalid indexes", n)
 }

--- a/checks/invalidindexes/check_test.go
+++ b/checks/invalidindexes/check_test.go
@@ -33,83 +33,50 @@ func newMockQueryerWithError(err error) *mockInvalidIndexesQueryer {
 }
 
 func brokenIndex(schema, table, index string) db.BrokenIndexesRow {
-	return db.BrokenIndexesRow{
-		SchemaName: schema,
-		TableName:  table,
-		IndexName:  index,
-		IsLeftover: false,
-	}
+	return db.BrokenIndexesRow{SchemaName: schema, TableName: table, IndexName: index, IsLeftover: false}
 }
 
 func leftoverIndex(schema, table, index string) db.BrokenIndexesRow {
-	return db.BrokenIndexesRow{
-		SchemaName: schema,
-		TableName:  table,
-		IndexName:  index,
-		IsLeftover: true,
-	}
+	return db.BrokenIndexesRow{SchemaName: schema, TableName: table, IndexName: index, IsLeftover: true}
 }
 
-// findingByID returns the finding with the given ID, failing the test if absent.
-func findingByID(t *testing.T, report *check.Report, id string) check.Finding {
+// onlyFinding returns the single finding the check always emits.
+func onlyFinding(t *testing.T, report *check.Report) check.Finding {
 	t.Helper()
-	for _, f := range report.Results {
-		if f.ID == id {
-			return f
-		}
-	}
-	require.Failf(t, "finding not found", "no finding with ID %q", id)
-	return check.Finding{}
+	require.Len(t, report.Results, 1, "invalid-indexes emits exactly one finding")
+	return report.Results[0]
 }
 
-func Test_InvalidIndexes(t *testing.T) {
+func Test_InvalidIndexes_Severity(t *testing.T) {
 	t.Parallel()
 
-	type testCase struct {
-		Name             string
-		Indexes          []db.BrokenIndexesRow
-		ReportSeverity   check.Severity
-		BrokenSeverity   check.Severity
-		LeftoverSeverity check.Severity
-	}
-
-	testCases := []testCase{
+	testCases := []struct {
+		Name     string
+		Indexes  []db.BrokenIndexesRow
+		Severity check.Severity
+	}{
 		{
-			Name:             "no rows - both OK, report OK",
-			Indexes:          []db.BrokenIndexesRow{},
-			ReportSeverity:   check.SeverityOK,
-			BrokenSeverity:   check.SeverityOK,
-			LeftoverSeverity: check.SeverityOK,
+			Name:     "no invalid indexes - OK",
+			Indexes:  []db.BrokenIndexesRow{},
+			Severity: check.SeverityOK,
 		},
 		{
-			Name: "only broken - broken FAIL, leftovers OK, report FAIL",
-			Indexes: []db.BrokenIndexesRow{
-				brokenIndex("public", "users", "idx_users_email"),
-				brokenIndex("public", "posts", "idx_posts_created_at"),
-			},
-			ReportSeverity:   check.SeverityFail,
-			BrokenSeverity:   check.SeverityFail,
-			LeftoverSeverity: check.SeverityOK,
+			Name:     "broken index - WARN",
+			Indexes:  []db.BrokenIndexesRow{brokenIndex("public", "users", "idx_users_email")},
+			Severity: check.SeverityWarn,
 		},
 		{
-			Name: "only leftovers - broken OK, leftovers WARN, report WARN",
-			Indexes: []db.BrokenIndexesRow{
-				leftoverIndex("public", "users", "idx_users_email_ccnew"),
-				leftoverIndex("public", "posts", "idx_posts_created_at_ccold1"),
-			},
-			ReportSeverity:   check.SeverityWarn,
-			BrokenSeverity:   check.SeverityOK,
-			LeftoverSeverity: check.SeverityWarn,
+			Name:     "abandoned leftover - WARN",
+			Indexes:  []db.BrokenIndexesRow{leftoverIndex("public", "users", "idx_users_email_ccnew")},
+			Severity: check.SeverityWarn,
 		},
 		{
-			Name: "mixed - broken FAIL, leftovers WARN, report FAIL",
+			Name: "mixed - WARN",
 			Indexes: []db.BrokenIndexesRow{
 				brokenIndex("public", "users", "idx_users_email"),
 				leftoverIndex("app", "orders", "idx_orders_status_ccnew"),
 			},
-			ReportSeverity:   check.SeverityFail,
-			BrokenSeverity:   check.SeverityFail,
-			LeftoverSeverity: check.SeverityWarn,
+			Severity: check.SeverityWarn,
 		},
 	}
 
@@ -121,107 +88,31 @@ func Test_InvalidIndexes(t *testing.T) {
 			report, err := checker.Check(context.Background())
 			require.NoError(t, err)
 
-			require.Equal(t, check.CategoryIndexes, report.Category, "Category should be indexes")
-			require.Len(t, report.Results, 2, "Should always emit exactly 2 findings")
-			require.Equal(t, tc.ReportSeverity, report.Severity, "Report severity should be the max")
+			require.Equal(t, check.CategoryIndexes, report.Category)
+			require.Equal(t, "invalid-indexes", report.CheckID)
+			require.Equal(t, tc.Severity, report.Severity)
 
-			broken := findingByID(t, report, "broken-indexes")
-			require.Equal(t, tc.BrokenSeverity, broken.Severity, "broken-indexes severity")
-
-			leftovers := findingByID(t, report, "abandoned-leftovers")
-			require.Equal(t, tc.LeftoverSeverity, leftovers.Severity, "abandoned-leftovers severity")
+			finding := onlyFinding(t, report)
+			require.Equal(t, "invalid-indexes", finding.ID)
+			require.Equal(t, tc.Severity, finding.Severity)
 		})
 	}
 }
 
-func Test_InvalidIndexes_NoRows_Details(t *testing.T) {
+func Test_InvalidIndexes_OK_NoDetailsNoTable(t *testing.T) {
 	t.Parallel()
 
 	checker := invalidindexes.New(newMockQueryer(nil))
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
 
-	broken := findingByID(t, report, "broken-indexes")
-	require.Equal(t, check.SeverityOK, broken.Severity)
-	require.Nil(t, broken.Table, "OK broken finding should have no table")
-	require.Contains(t, broken.Details, "No broken indexes")
-
-	leftovers := findingByID(t, report, "abandoned-leftovers")
-	require.Equal(t, check.SeverityOK, leftovers.Severity)
-	require.Nil(t, leftovers.Table, "OK leftover finding should have no table")
-	require.Contains(t, leftovers.Details, "No abandoned")
+	finding := onlyFinding(t, report)
+	require.Equal(t, check.SeverityOK, finding.Severity)
+	require.Empty(t, finding.Details, "OK finding carries no details")
+	require.Nil(t, finding.Table, "OK finding carries no table")
 }
 
-func Test_InvalidIndexes_Broken_TableAndRemediation(t *testing.T) {
-	t.Parallel()
-
-	indexes := []db.BrokenIndexesRow{
-		brokenIndex("public", "users", "idx_users_email"),
-		brokenIndex("app", "posts", "idx_posts_created_at"),
-	}
-
-	checker := invalidindexes.New(newMockQueryer(indexes))
-	report, err := checker.Check(context.Background())
-	require.NoError(t, err)
-
-	broken := findingByID(t, report, "broken-indexes")
-	require.Equal(t, check.SeverityFail, broken.Severity)
-
-	// Count phrasing (plural).
-	require.Contains(t, broken.Details, "2 broken indexes")
-
-	// Remediation commands present.
-	require.Contains(t, broken.Details, "REINDEX INDEX CONCURRENTLY")
-	require.Contains(t, broken.Details, "DROP INDEX CONCURRENTLY")
-
-	// Table contains exactly the broken rows with the right cells.
-	require.NotNil(t, broken.Table)
-	require.Equal(t, []string{"Schema", "Table", "Index"}, broken.Table.Headers)
-	require.Len(t, broken.Table.Rows, 2)
-	require.Equal(t, []string{"public", "users", "idx_users_email"}, broken.Table.Rows[0].Cells)
-	require.Equal(t, []string{"app", "posts", "idx_posts_created_at"}, broken.Table.Rows[1].Cells)
-	require.Equal(t, check.SeverityFail, broken.Table.Rows[0].Severity)
-
-	// The leftover finding stays OK with no table.
-	leftovers := findingByID(t, report, "abandoned-leftovers")
-	require.Equal(t, check.SeverityOK, leftovers.Severity)
-	require.Nil(t, leftovers.Table)
-}
-
-func Test_InvalidIndexes_Leftovers_TableAndRemediation(t *testing.T) {
-	t.Parallel()
-
-	indexes := []db.BrokenIndexesRow{
-		leftoverIndex("public", "users", "idx_users_email_ccnew"),
-	}
-
-	checker := invalidindexes.New(newMockQueryer(indexes))
-	report, err := checker.Check(context.Background())
-	require.NoError(t, err)
-
-	leftovers := findingByID(t, report, "abandoned-leftovers")
-	require.Equal(t, check.SeverityWarn, leftovers.Severity)
-
-	// Count phrasing (singular).
-	require.Contains(t, leftovers.Details, "1 abandoned leftover index")
-
-	// Remediation command present (DROP only for leftovers).
-	require.Contains(t, leftovers.Details, "DROP INDEX CONCURRENTLY")
-	require.NotContains(t, leftovers.Details, "REINDEX INDEX CONCURRENTLY")
-
-	require.NotNil(t, leftovers.Table)
-	require.Equal(t, []string{"Schema", "Table", "Index"}, leftovers.Table.Headers)
-	require.Len(t, leftovers.Table.Rows, 1)
-	require.Equal(t, []string{"public", "users", "idx_users_email_ccnew"}, leftovers.Table.Rows[0].Cells)
-	require.Equal(t, check.SeverityWarn, leftovers.Table.Rows[0].Severity)
-
-	// The broken finding stays OK with no table.
-	broken := findingByID(t, report, "broken-indexes")
-	require.Equal(t, check.SeverityOK, broken.Severity)
-	require.Nil(t, broken.Table)
-}
-
-func Test_InvalidIndexes_Mixed_Partitioning(t *testing.T) {
+func Test_InvalidIndexes_ClassifiesRowsByType(t *testing.T) {
 	t.Parallel()
 
 	indexes := []db.BrokenIndexesRow{
@@ -234,28 +125,46 @@ func Test_InvalidIndexes_Mixed_Partitioning(t *testing.T) {
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
 
-	require.Equal(t, check.SeverityFail, report.Severity)
+	finding := onlyFinding(t, report)
+	require.Equal(t, check.SeverityWarn, finding.Severity)
 
-	broken := findingByID(t, report, "broken-indexes")
-	require.Equal(t, check.SeverityFail, broken.Severity)
-	require.Contains(t, broken.Details, "2 broken indexes")
-	require.NotNil(t, broken.Table)
-	require.Len(t, broken.Table.Rows, 2)
+	// Terse summary with the per-class breakdown.
+	require.Contains(t, finding.Details, "3 invalid indexes")
+	require.Contains(t, finding.Details, "2 broken")
+	require.Contains(t, finding.Details, "1 leftover")
 
-	leftovers := findingByID(t, report, "abandoned-leftovers")
-	require.Equal(t, check.SeverityWarn, leftovers.Severity)
-	require.Contains(t, leftovers.Details, "1 abandoned leftover index")
-	require.NotNil(t, leftovers.Table)
-	require.Len(t, leftovers.Table.Rows, 1)
-	require.Equal(t, []string{"app", "posts", "idx_posts_created_at_ccnew"}, leftovers.Table.Rows[0].Cells)
+	// Fix instructions stay out of the run output (README / explain only).
+	require.NotContains(t, finding.Details, "CONCURRENTLY")
+
+	// Table carries the broken/leftover distinction in a Type column.
+	require.NotNil(t, finding.Table)
+	require.Equal(t, []string{"Schema", "Table", "Index", "Type"}, finding.Table.Headers)
+	require.Len(t, finding.Table.Rows, 3)
+	require.Equal(t, []string{"public", "users", "idx_users_email", "broken"}, finding.Table.Rows[0].Cells)
+	require.Equal(t, []string{"app", "posts", "idx_posts_created_at_ccnew", "leftover"}, finding.Table.Rows[2].Cells)
+	for _, row := range finding.Table.Rows {
+		require.Equal(t, check.SeverityWarn, row.Severity)
+	}
+}
+
+func Test_InvalidIndexes_SingularPhrasing(t *testing.T) {
+	t.Parallel()
+
+	checker := invalidindexes.New(newMockQueryer([]db.BrokenIndexesRow{
+		leftoverIndex("public", "users", "idx_users_email_ccnew"),
+	}))
+	report, err := checker.Check(context.Background())
+	require.NoError(t, err)
+
+	finding := onlyFinding(t, report)
+	require.Contains(t, finding.Details, "1 invalid index ")
+	require.NotContains(t, finding.Details, "invalid indexes")
 }
 
 func Test_InvalidIndexes_QueryError(t *testing.T) {
 	t.Parallel()
 
-	queryer := newMockQueryerWithError(fmt.Errorf("database connection error"))
-
-	checker := invalidindexes.New(queryer)
+	checker := invalidindexes.New(newMockQueryerWithError(fmt.Errorf("database connection error")))
 	_, err := checker.Check(context.Background())
 
 	require.Error(t, err)
@@ -267,10 +176,10 @@ func Test_InvalidIndexes_Metadata(t *testing.T) {
 
 	m := invalidindexes.Metadata()
 
-	require.Equal(t, "invalid-indexes", m.CheckID, "CheckID should match")
-	require.Equal(t, "Invalid Indexes", m.Name, "Name should match")
-	require.Equal(t, check.CategoryIndexes, m.Category, "Category should be indexes")
-	require.NotEmpty(t, m.Description, "Description should not be empty")
-	require.NotEmpty(t, m.SQL, "SQL should not be empty")
-	require.NotEmpty(t, m.Readme, "Readme should not be empty")
+	require.Equal(t, "invalid-indexes", m.CheckID)
+	require.Equal(t, "Invalid Indexes", m.Name)
+	require.Equal(t, check.CategoryIndexes, m.Category)
+	require.NotEmpty(t, m.Description)
+	require.NotEmpty(t, m.SQL)
+	require.NotEmpty(t, m.Readme)
 }

--- a/checks/invalidindexes/check_test.go
+++ b/checks/invalidindexes/check_test.go
@@ -32,40 +32,84 @@ func newMockQueryerWithError(err error) *mockInvalidIndexesQueryer {
 	return &mockInvalidIndexesQueryer{err: err}
 }
 
+func brokenIndex(schema, table, index string) db.BrokenIndexesRow {
+	return db.BrokenIndexesRow{
+		SchemaName: schema,
+		TableName:  table,
+		IndexName:  index,
+		IsLeftover: false,
+	}
+}
+
+func leftoverIndex(schema, table, index string) db.BrokenIndexesRow {
+	return db.BrokenIndexesRow{
+		SchemaName: schema,
+		TableName:  table,
+		IndexName:  index,
+		IsLeftover: true,
+	}
+}
+
+// findingByID returns the finding with the given ID, failing the test if absent.
+func findingByID(t *testing.T, report *check.Report, id string) check.Finding {
+	t.Helper()
+	for _, f := range report.Results {
+		if f.ID == id {
+			return f
+		}
+	}
+	require.Failf(t, "finding not found", "no finding with ID %q", id)
+	return check.Finding{}
+}
+
 func Test_InvalidIndexes(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
 		Name             string
 		Indexes          []db.BrokenIndexesRow
-		ExpectedSeverity check.Severity
-		ExpectedID       string
+		ReportSeverity   check.Severity
+		BrokenSeverity   check.Severity
+		LeftoverSeverity check.Severity
 	}
 
 	testCases := []testCase{
 		{
-			Name:             "no invalid indexes - OK",
+			Name:             "no rows - both OK, report OK",
 			Indexes:          []db.BrokenIndexesRow{},
-			ExpectedSeverity: check.SeverityOK,
-			ExpectedID:       "invalid-indexes",
+			ReportSeverity:   check.SeverityOK,
+			BrokenSeverity:   check.SeverityOK,
+			LeftoverSeverity: check.SeverityOK,
 		},
 		{
-			Name: "one invalid index - WARN",
+			Name: "only broken - broken FAIL, leftovers OK, report FAIL",
 			Indexes: []db.BrokenIndexesRow{
-				{TableName: "users", IndexName: "idx_users_email"},
+				brokenIndex("public", "users", "idx_users_email"),
+				brokenIndex("public", "posts", "idx_posts_created_at"),
 			},
-			ExpectedSeverity: check.SeverityWarn,
-			ExpectedID:       "invalid-indexes",
+			ReportSeverity:   check.SeverityFail,
+			BrokenSeverity:   check.SeverityFail,
+			LeftoverSeverity: check.SeverityOK,
 		},
 		{
-			Name: "multiple invalid indexes - WARN",
+			Name: "only leftovers - broken OK, leftovers WARN, report WARN",
 			Indexes: []db.BrokenIndexesRow{
-				{TableName: "users", IndexName: "idx_users_email"},
-				{TableName: "posts", IndexName: "idx_posts_created_at"},
-				{TableName: "comments", IndexName: "idx_comments_user_id"},
+				leftoverIndex("public", "users", "idx_users_email_ccnew"),
+				leftoverIndex("public", "posts", "idx_posts_created_at_ccold1"),
 			},
-			ExpectedSeverity: check.SeverityWarn,
-			ExpectedID:       "invalid-indexes",
+			ReportSeverity:   check.SeverityWarn,
+			BrokenSeverity:   check.SeverityOK,
+			LeftoverSeverity: check.SeverityWarn,
+		},
+		{
+			Name: "mixed - broken FAIL, leftovers WARN, report FAIL",
+			Indexes: []db.BrokenIndexesRow{
+				brokenIndex("public", "users", "idx_users_email"),
+				leftoverIndex("app", "orders", "idx_orders_status_ccnew"),
+			},
+			ReportSeverity:   check.SeverityFail,
+			BrokenSeverity:   check.SeverityFail,
+			LeftoverSeverity: check.SeverityWarn,
 		},
 	}
 
@@ -73,217 +117,160 @@ func Test_InvalidIndexes(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			queryer := newMockQueryer(tc.Indexes)
-
-			checker := invalidindexes.New(queryer)
+			checker := invalidindexes.New(newMockQueryer(tc.Indexes))
 			report, err := checker.Check(context.Background())
 			require.NoError(t, err)
 
-			results := report.Results
-			require.Equal(t, 1, len(results), "Should have exactly 1 result")
-
-			result := results[0]
-			require.Equal(t, tc.ExpectedID, result.ID, "Result ID should match")
-			require.Equal(t, tc.ExpectedSeverity, result.Severity, "Result severity should match")
 			require.Equal(t, check.CategoryIndexes, report.Category, "Category should be indexes")
+			require.Len(t, report.Results, 2, "Should always emit exactly 2 findings")
+			require.Equal(t, tc.ReportSeverity, report.Severity, "Report severity should be the max")
+
+			broken := findingByID(t, report, "broken-indexes")
+			require.Equal(t, tc.BrokenSeverity, broken.Severity, "broken-indexes severity")
+
+			leftovers := findingByID(t, report, "abandoned-leftovers")
+			require.Equal(t, tc.LeftoverSeverity, leftovers.Severity, "abandoned-leftovers severity")
 		})
 	}
 }
 
-func Test_InvalidIndexes_DetailsContent(t *testing.T) {
+func Test_InvalidIndexes_NoRows_Details(t *testing.T) {
+	t.Parallel()
+
+	checker := invalidindexes.New(newMockQueryer(nil))
+	report, err := checker.Check(context.Background())
+	require.NoError(t, err)
+
+	broken := findingByID(t, report, "broken-indexes")
+	require.Equal(t, check.SeverityOK, broken.Severity)
+	require.Nil(t, broken.Table, "OK broken finding should have no table")
+	require.Contains(t, broken.Details, "No broken indexes")
+
+	leftovers := findingByID(t, report, "abandoned-leftovers")
+	require.Equal(t, check.SeverityOK, leftovers.Severity)
+	require.Nil(t, leftovers.Table, "OK leftover finding should have no table")
+	require.Contains(t, leftovers.Details, "No abandoned")
+}
+
+func Test_InvalidIndexes_Broken_TableAndRemediation(t *testing.T) {
 	t.Parallel()
 
 	indexes := []db.BrokenIndexesRow{
-		{TableName: "users", IndexName: "idx_users_email"},
-		{TableName: "posts", IndexName: "idx_posts_created_at"},
+		brokenIndex("public", "users", "idx_users_email"),
+		brokenIndex("app", "posts", "idx_posts_created_at"),
 	}
 
-	queryer := newMockQueryer(indexes)
-
-	checker := invalidindexes.New(queryer)
+	checker := invalidindexes.New(newMockQueryer(indexes))
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
 
-	results := report.Results
-	require.Equal(t, 1, len(results), "Should have exactly 1 result")
+	broken := findingByID(t, report, "broken-indexes")
+	require.Equal(t, check.SeverityFail, broken.Severity)
 
-	result := results[0]
-	require.Equal(t, check.SeverityWarn, result.Severity)
+	// Count phrasing (plural).
+	require.Contains(t, broken.Details, "2 broken indexes")
 
-	// Verify details contain count
-	require.Contains(t, result.Details, "2 invalid indexes", "Details should mention count")
+	// Remediation commands present.
+	require.Contains(t, broken.Details, "REINDEX INDEX CONCURRENTLY")
+	require.Contains(t, broken.Details, "DROP INDEX CONCURRENTLY")
 
-	// Verify details contain table and index names
-	require.Contains(t, result.Details, "users", "Details should contain table name")
-	require.Contains(t, result.Details, "idx_users_email", "Details should contain index name")
-	require.Contains(t, result.Details, "posts", "Details should contain table name")
-	require.Contains(t, result.Details, "idx_posts_created_at", "Details should contain index name")
+	// Table contains exactly the broken rows with the right cells.
+	require.NotNil(t, broken.Table)
+	require.Equal(t, []string{"Schema", "Table", "Index"}, broken.Table.Headers)
+	require.Len(t, broken.Table.Rows, 2)
+	require.Equal(t, []string{"public", "users", "idx_users_email"}, broken.Table.Rows[0].Cells)
+	require.Equal(t, []string{"app", "posts", "idx_posts_created_at"}, broken.Table.Rows[1].Cells)
+	require.Equal(t, check.SeverityFail, broken.Table.Rows[0].Severity)
+
+	// The leftover finding stays OK with no table.
+	leftovers := findingByID(t, report, "abandoned-leftovers")
+	require.Equal(t, check.SeverityOK, leftovers.Severity)
+	require.Nil(t, leftovers.Table)
 }
 
-func Test_InvalidIndexes_PrescriptionContent(t *testing.T) {
+func Test_InvalidIndexes_Leftovers_TableAndRemediation(t *testing.T) {
 	t.Parallel()
 
 	indexes := []db.BrokenIndexesRow{
-		{TableName: "users", IndexName: "idx_users_email"},
+		leftoverIndex("public", "users", "idx_users_email_ccnew"),
 	}
 
-	queryer := newMockQueryer(indexes)
-
-	checker := invalidindexes.New(queryer)
+	checker := invalidindexes.New(newMockQueryer(indexes))
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
 
-	results := report.Results
-	require.Equal(t, 1, len(results), "Should have exactly 1 result")
+	leftovers := findingByID(t, report, "abandoned-leftovers")
+	require.Equal(t, check.SeverityWarn, leftovers.Severity)
 
-	result := results[0]
-	require.NotEmpty(t, result.Details, "Details should not be empty")
+	// Count phrasing (singular).
+	require.Contains(t, leftovers.Details, "1 abandoned leftover index")
+
+	// Remediation command present (DROP only for leftovers).
+	require.Contains(t, leftovers.Details, "DROP INDEX CONCURRENTLY")
+	require.NotContains(t, leftovers.Details, "REINDEX INDEX CONCURRENTLY")
+
+	require.NotNil(t, leftovers.Table)
+	require.Equal(t, []string{"Schema", "Table", "Index"}, leftovers.Table.Headers)
+	require.Len(t, leftovers.Table.Rows, 1)
+	require.Equal(t, []string{"public", "users", "idx_users_email_ccnew"}, leftovers.Table.Rows[0].Cells)
+	require.Equal(t, check.SeverityWarn, leftovers.Table.Rows[0].Severity)
+
+	// The broken finding stays OK with no table.
+	broken := findingByID(t, report, "broken-indexes")
+	require.Equal(t, check.SeverityOK, broken.Severity)
+	require.Nil(t, broken.Table)
 }
 
-func Test_InvalidIndexes_OKResult(t *testing.T) {
+func Test_InvalidIndexes_Mixed_Partitioning(t *testing.T) {
 	t.Parallel()
 
-	// No invalid indexes
-	queryer := newMockQueryer([]db.BrokenIndexesRow{})
+	indexes := []db.BrokenIndexesRow{
+		brokenIndex("public", "users", "idx_users_email"),
+		brokenIndex("public", "orders", "idx_orders_status"),
+		leftoverIndex("app", "posts", "idx_posts_created_at_ccnew"),
+	}
 
-	checker := invalidindexes.New(queryer)
+	checker := invalidindexes.New(newMockQueryer(indexes))
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
 
-	results := report.Results
-	require.Equal(t, 1, len(results), "Should have exactly 1 result")
+	require.Equal(t, check.SeverityFail, report.Severity)
 
-	result := results[0]
-	require.Equal(t, check.SeverityOK, result.Severity, "Should be OK when no invalid indexes")
-	require.Empty(t, result.Details, "Details should be empty for OK result")
+	broken := findingByID(t, report, "broken-indexes")
+	require.Equal(t, check.SeverityFail, broken.Severity)
+	require.Contains(t, broken.Details, "2 broken indexes")
+	require.NotNil(t, broken.Table)
+	require.Len(t, broken.Table.Rows, 2)
+
+	leftovers := findingByID(t, report, "abandoned-leftovers")
+	require.Equal(t, check.SeverityWarn, leftovers.Severity)
+	require.Contains(t, leftovers.Details, "1 abandoned leftover index")
+	require.NotNil(t, leftovers.Table)
+	require.Len(t, leftovers.Table.Rows, 1)
+	require.Equal(t, []string{"app", "posts", "idx_posts_created_at_ccnew"}, leftovers.Table.Rows[0].Cells)
 }
 
 func Test_InvalidIndexes_QueryError(t *testing.T) {
 	t.Parallel()
 
-	// Mock query error
-	expectedErr := fmt.Errorf("database connection error")
-	queryer := newMockQueryerWithError(expectedErr)
+	queryer := newMockQueryerWithError(fmt.Errorf("database connection error"))
 
 	checker := invalidindexes.New(queryer)
 	_, err := checker.Check(context.Background())
 
-	require.Error(t, err, "Should return error when query fails")
-	require.Contains(t, err.Error(), "invalid-indexes", "Error should mention check ID")
-}
-
-func Test_InvalidIndexes_CategoryFiltering(t *testing.T) {
-	t.Parallel()
-
-	indexes := []db.BrokenIndexesRow{
-		{TableName: "users", IndexName: "idx_users_email"},
-	}
-
-	queryer := newMockQueryer(indexes)
-
-	// Create report with indexes category filtered out
-
-	// Use the actual runner which handles filtering
-	// We can't test filtering directly here since Report is internal
-	// but we can verify the check respects the reporter interface
-	checker := invalidindexes.New(queryer)
-	report, err := checker.Check(context.Background())
-	require.NoError(t, err)
-
-	// Should still run and add result when not filtered
-	results := report.Results
-	require.Equal(t, 1, len(results), "Should have result when not filtered")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid-indexes")
 }
 
 func Test_InvalidIndexes_Metadata(t *testing.T) {
 	t.Parallel()
 
-	queryer := newMockQueryer([]db.BrokenIndexesRow{})
-	checker := invalidindexes.New(queryer)
-	metadata := checker.Metadata()
+	m := invalidindexes.Metadata()
 
-	require.Equal(t, "invalid-indexes", metadata.CheckID, "CheckID should match")
-	require.Equal(t, "Invalid Indexes", metadata.Name, "Name should match")
-	require.Equal(t, check.CategoryIndexes, metadata.Category, "Category should be indexes")
-	require.NotEmpty(t, metadata.Description, "Description should not be empty")
-}
-
-func Test_InvalidIndexes_ResultStructure(t *testing.T) {
-	t.Parallel()
-
-	indexes := []db.BrokenIndexesRow{
-		{TableName: "orders", IndexName: "idx_orders_status"},
-	}
-
-	queryer := newMockQueryer(indexes)
-
-	checker := invalidindexes.New(queryer)
-	report, err := checker.Check(context.Background())
-	require.NoError(t, err)
-
-	results := report.Results
-	require.Equal(t, 1, len(results))
-
-	result := results[0]
-	require.Equal(t, "Invalid Indexes", result.Name, "Name should match")
-	require.Equal(t, "invalid-indexes", report.CheckID, "CheckID should match")
-	require.Equal(t, "invalid-indexes", result.ID, "ID should match CheckID")
-	require.Equal(t, check.CategoryIndexes, report.Category, "Category should match")
-	require.Equal(t, check.SeverityWarn, result.Severity, "Severity should be WARN for invalid indexes")
-	require.NotEmpty(t, result.Details, "Details should not be empty")
-}
-
-func Test_InvalidIndexes_CountAccuracy(t *testing.T) {
-	t.Parallel()
-
-	type testCase struct {
-		Name          string
-		IndexCount    int
-		ExpectedCount string
-	}
-
-	testCases := []testCase{
-		{
-			Name:          "single invalid index",
-			IndexCount:    1,
-			ExpectedCount: "1 invalid index",
-		},
-		{
-			Name:          "five invalid indexes",
-			IndexCount:    5,
-			ExpectedCount: "5 invalid indexes",
-		},
-		{
-			Name:          "ten invalid indexes",
-			IndexCount:    10,
-			ExpectedCount: "10 invalid indexes",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
-
-			// Generate N invalid indexes
-			indexes := make([]db.BrokenIndexesRow, tc.IndexCount)
-			for i := 0; i < tc.IndexCount; i++ {
-				indexes[i] = db.BrokenIndexesRow{
-					TableName: fmt.Sprintf("table_%d", i),
-					IndexName: fmt.Sprintf("idx_table_%d_column", i),
-				}
-			}
-
-			queryer := newMockQueryer(indexes)
-
-			checker := invalidindexes.New(queryer)
-			report, err := checker.Check(context.Background())
-			require.NoError(t, err)
-
-			results := report.Results
-			require.Equal(t, 1, len(results))
-
-			result := results[0]
-			require.Contains(t, result.Details, tc.ExpectedCount, "Details should contain accurate count")
-		})
-	}
+	require.Equal(t, "invalid-indexes", m.CheckID, "CheckID should match")
+	require.Equal(t, "Invalid Indexes", m.Name, "Name should match")
+	require.Equal(t, check.CategoryIndexes, m.Category, "Category should be indexes")
+	require.NotEmpty(t, m.Description, "Description should not be empty")
+	require.NotEmpty(t, m.SQL, "SQL should not be empty")
+	require.NotEmpty(t, m.Readme, "Readme should not be empty")
 }

--- a/checks/invalidindexes/query.sql
+++ b/checks/invalidindexes/query.sql
@@ -1,8 +1,27 @@
 -- name: BrokenIndexes :many
+-- Reports indexes that are NOT indisvalid, classifying each as either a
+-- genuinely-broken index (is_leftover = false -> FAIL) or an abandoned
+-- REINDEX CONCURRENTLY transient (_ccnew/_ccold family, is_leftover = true -> WARN).
+-- Excludes indexes currently being built: during CREATE INDEX CONCURRENTLY and
+-- REINDEX INDEX CONCURRENTLY, pg_stat_progress_create_index.index_relid points
+-- to the new (invalid) index OID, so an active progress row means "in flight,
+-- not broken" (verified against PG15/PG16 ReindexRelationConcurrently).
+-- Schema exclusion is intentionally narrower than duplicateindexes: an invalid
+-- index in cron/pgpartman/debezium is a real operational problem worth reporting,
+-- whereas a *duplicate* design choice there is not ours to fix.
 SELECT
-  tblclass.relname AS table_name
-  , idxclass.relname AS index_name
-FROM pg_index
-INNER JOIN pg_class AS idxclass ON pg_index.indexrelid = idxclass.oid
-INNER JOIN pg_class AS tblclass ON pg_index.indrelid = tblclass.oid
-WHERE NOT pg_index.indisvalid;
+  n.nspname::text AS schema_name
+  , tbl.relname::text AS table_name
+  , idx.relname::text AS index_name
+  , (idx.relname ~ '_cc(new|old)[0-9]*$') AS is_leftover
+FROM pg_index AS i
+INNER JOIN pg_class AS idx ON i.indexrelid = idx.oid
+INNER JOIN pg_class AS tbl ON i.indrelid = tbl.oid
+INNER JOIN pg_namespace AS n ON tbl.relnamespace = n.oid
+WHERE NOT i.indisvalid
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+  AND NOT EXISTS (
+    SELECT 1 FROM pg_stat_progress_create_index AS p
+    WHERE p.index_relid = i.indexrelid
+  )
+ORDER BY is_leftover, n.nspname, tbl.relname, idx.relname;

--- a/checks/invalidindexes/query.sql
+++ b/checks/invalidindexes/query.sql
@@ -1,14 +1,7 @@
 -- name: BrokenIndexes :many
--- Reports indexes that are NOT indisvalid, classifying each as either a
--- genuinely-broken index (is_leftover = false -> FAIL) or an abandoned
--- REINDEX CONCURRENTLY transient (_ccnew/_ccold family, is_leftover = true -> WARN).
--- Excludes indexes currently being built: during CREATE INDEX CONCURRENTLY and
--- REINDEX INDEX CONCURRENTLY, pg_stat_progress_create_index.index_relid points
--- to the new (invalid) index OID, so an active progress row means "in flight,
--- not broken" (verified against PG15/PG16 ReindexRelationConcurrently).
--- Schema exclusion is intentionally narrower than duplicateindexes: an invalid
--- index in cron/pgpartman/debezium is a real operational problem worth reporting,
--- whereas a *duplicate* design choice there is not ours to fix.
+-- Invalid indexes, flagging _ccnew/_ccold REINDEX CONCURRENTLY leftovers via
+-- is_leftover. Excludes indexes a concurrent build is still working on (their
+-- index_relid is in pg_stat_progress_create_index): in flight, not broken.
 SELECT
   n.nspname::text AS schema_name
   , tbl.relname::text AS table_name

--- a/db/query.sql.go
+++ b/db/query.sql.go
@@ -37,16 +37,9 @@ type BrokenIndexesRow struct {
 	IsLeftover bool
 }
 
-// Reports indexes that are NOT indisvalid, classifying each as either a
-// genuinely-broken index (is_leftover = false -> FAIL) or an abandoned
-// REINDEX CONCURRENTLY transient (_ccnew/_ccold family, is_leftover = true -> WARN).
-// Excludes indexes currently being built: during CREATE INDEX CONCURRENTLY and
-// REINDEX INDEX CONCURRENTLY, pg_stat_progress_create_index.index_relid points
-// to the new (invalid) index OID, so an active progress row means "in flight,
-// not broken" (verified against PG15/PG16 ReindexRelationConcurrently).
-// Schema exclusion is intentionally narrower than duplicateindexes: an invalid
-// index in cron/pgpartman/debezium is a real operational problem worth reporting,
-// whereas a *duplicate* design choice there is not ours to fix.
+// Invalid indexes, flagging _ccnew/_ccold REINDEX CONCURRENTLY leftovers via
+// is_leftover. Excludes indexes a concurrent build is still working on (their
+// index_relid is in pg_stat_progress_create_index): in flight, not broken.
 func (q *Queries) BrokenIndexes(ctx context.Context) ([]BrokenIndexesRow, error) {
 	rows, err := q.db.Query(ctx, brokenIndexes)
 	if err != nil {

--- a/db/query.sql.go
+++ b/db/query.sql.go
@@ -13,19 +13,40 @@ import (
 
 const brokenIndexes = `-- name: BrokenIndexes :many
 SELECT
-  tblclass.relname AS table_name
-  , idxclass.relname AS index_name
-FROM pg_index
-INNER JOIN pg_class AS idxclass ON pg_index.indexrelid = idxclass.oid
-INNER JOIN pg_class AS tblclass ON pg_index.indrelid = tblclass.oid
-WHERE NOT pg_index.indisvalid
+  n.nspname::text AS schema_name
+  , tbl.relname::text AS table_name
+  , idx.relname::text AS index_name
+  , (idx.relname ~ '_cc(new|old)[0-9]*$') AS is_leftover
+FROM pg_index AS i
+INNER JOIN pg_class AS idx ON i.indexrelid = idx.oid
+INNER JOIN pg_class AS tbl ON i.indrelid = tbl.oid
+INNER JOIN pg_namespace AS n ON tbl.relnamespace = n.oid
+WHERE NOT i.indisvalid
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+  AND NOT EXISTS (
+    SELECT 1 FROM pg_stat_progress_create_index AS p
+    WHERE p.index_relid = i.indexrelid
+  )
+ORDER BY is_leftover, n.nspname, tbl.relname, idx.relname
 `
 
 type BrokenIndexesRow struct {
-	TableName string
-	IndexName string
+	SchemaName string
+	TableName  string
+	IndexName  string
+	IsLeftover bool
 }
 
+// Reports indexes that are NOT indisvalid, classifying each as either a
+// genuinely-broken index (is_leftover = false -> FAIL) or an abandoned
+// REINDEX CONCURRENTLY transient (_ccnew/_ccold family, is_leftover = true -> WARN).
+// Excludes indexes currently being built: during CREATE INDEX CONCURRENTLY and
+// REINDEX INDEX CONCURRENTLY, pg_stat_progress_create_index.index_relid points
+// to the new (invalid) index OID, so an active progress row means "in flight,
+// not broken" (verified against PG15/PG16 ReindexRelationConcurrently).
+// Schema exclusion is intentionally narrower than duplicateindexes: an invalid
+// index in cron/pgpartman/debezium is a real operational problem worth reporting,
+// whereas a *duplicate* design choice there is not ours to fix.
 func (q *Queries) BrokenIndexes(ctx context.Context) ([]BrokenIndexesRow, error) {
 	rows, err := q.db.Query(ctx, brokenIndexes)
 	if err != nil {
@@ -35,7 +56,12 @@ func (q *Queries) BrokenIndexes(ctx context.Context) ([]BrokenIndexesRow, error)
 	var items []BrokenIndexesRow
 	for rows.Next() {
 		var i BrokenIndexesRow
-		if err := rows.Scan(&i.TableName, &i.IndexName); err != nil {
+		if err := rows.Scan(
+			&i.SchemaName,
+			&i.TableName,
+			&i.IndexName,
+			&i.IsLeftover,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/docs/checks/invalid-indexes.md
+++ b/docs/checks/invalid-indexes.md
@@ -1,107 +1,45 @@
 # Invalid Indexes Check
 
-Identifies PostgreSQL indexes that are in an invalid state (`pg_index.indisvalid = false`)
-and not used by the query planner — while ignoring indexes that are merely being
-built right now.
+Finds indexes stuck in an invalid state (`pg_index.indisvalid = false`). The
+planner ignores them, so they cost disk without helping queries.
 
 ## What it checks
 
-An index ends up `indisvalid = false` for one of three reasons, and this check
-treats each differently:
+Reports each invalid index as **WARN**, classified by `Type`:
 
-1. **In-flight build (silently ignored).** While a `CREATE INDEX CONCURRENTLY` or
-   `REINDEX INDEX CONCURRENTLY` is running, the new index is invalid until the
-   build completes. The check excludes any index that has an active
-   `pg_stat_progress_create_index` row, because it is in flight, not broken.
+- **broken** — a `CREATE INDEX CONCURRENTLY` that failed or was interrupted, or
+  any other permanently-invalid index.
+- **leftover** — a `_ccnew`/`_ccold` transient left behind by a failed or
+  cancelled `REINDEX CONCURRENTLY`. The original index is still valid.
 
-2. **Broken index → FAIL.** A genuinely-broken index (`is_leftover = false`): a
-   `CREATE INDEX CONCURRENTLY` that failed or was interrupted, leaving a permanent
-   invalid index that the planner ignores. Reported under the `broken-indexes`
-   subcheck as **FAIL** when any exist.
+Indexes a `CREATE`/`REINDEX INDEX CONCURRENTLY` is *currently* building are
+excluded — they are invalid only until the build finishes (in flight, not
+broken). System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are
+excluded; `cron`/`pgpartman`/`debezium` are not, since an invalid index there is
+a real problem.
 
-3. **Abandoned REINDEX leftover → WARN.** A `_ccnew`/`_ccold` transient
-   (`is_leftover = true`) left behind by a failed or cancelled
-   `REINDEX CONCURRENTLY`. The original index is still valid, so these are
-   non-urgent clutter. Reported under the `abandoned-leftovers` subcheck as
-   **WARN** when any exist.
-
-Both subchecks are always emitted: each reports `OK` when its class is empty.
-The overall check severity is the maximum across the two findings.
-
-System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are excluded. An
-invalid index in `cron`/`pgpartman`/`debezium` is intentionally *not* excluded —
-unlike a duplicate index, an invalid index there is a real operational problem.
-
-## Why it matters
-
-Invalid indexes cause problems:
-
-- **Wasted disk space**: Invalid indexes consume storage but provide no benefit
-- **Query performance**: Not used by the query planner, defeating their purpose
-- **Hidden failures**: May indicate underlying data quality or operational issues
-- **Confusion**: Can mislead developers during query optimization
-
-## How to Fix
-
-### Broken indexes (FAIL)
-
-For each broken index, choose one of:
-
-**Rebuild the index** (preferred when the index is still wanted):
+## How to fix
 
 ```sql
-REINDEX INDEX CONCURRENTLY your_schema.your_index_name;
+-- broken: rebuild, or drop if the index is no longer wanted
+REINDEX INDEX CONCURRENTLY your_schema.your_index;
+DROP INDEX CONCURRENTLY your_schema.your_index;
+
+-- leftover: just drop it, the original index is still valid
+DROP INDEX CONCURRENTLY your_schema.your_leftover;
 ```
 
-**Drop the index** (if it is no longer needed):
+For a broken index, check the PostgreSQL logs for the original failure before
+rebuilding.
 
-```sql
-DROP INDEX CONCURRENTLY your_schema.your_index_name;
-```
+## Notes
 
-Before rebuilding:
-
-1. Investigate why the index failed initially
-2. Check for locking issues or timeout problems
-3. Verify the underlying data satisfies the index conditions
-4. Consider if the index definition needs modification
-
-### Abandoned REINDEX leftovers (WARN)
-
-The original index is still valid; the `_ccnew`/`_ccold` leftover can simply be
-dropped:
-
-```sql
-DROP INDEX CONCURRENTLY your_schema.your_leftover_index;
-```
-
-### Investigation Steps
-
-1. **Check index definition:**
-   ```sql
-   SELECT indexdef FROM pg_indexes WHERE indexname = 'your_index_name';
-   ```
-2. **Review PostgreSQL logs** for errors during index creation
-3. **Verify data integrity** — ensure data meets index constraints
-4. **Check for lock conflicts** that might have interrupted creation
-
-## Notes / caveats
-
-- **Read replicas.** On a standby, an in-flight build on the primary can briefly
-  surface its `_ccnew` index as a WARN: the standby sees the invalid index but
-  `pg_stat_progress_create_index` reflects only local backends, so the in-flight
-  exclusion does not apply. It clears once the primary finishes and the change
-  replays.
-- **Naming collisions.** A user index literally named `*_ccnew`/`*_ccold` that is
-  genuinely invalid would be classified as a WARN leftover rather than a FAIL.
-  This is rare and only affects severity, not detection.
-- **Classification can change between runs.** Whether a given `_ccnew` index is
-  reported (and as what) can change from one run to the next as a concurrent
-  reindex makes progress, completes, or its backend dies and leaves the transient
-  behind.
+- On a read replica, an in-flight build on the primary can briefly show its
+  `_ccnew` as a leftover (`pg_stat_progress_create_index` is local-only); it
+  clears once the build replays.
+- A user index literally named `*_ccnew`/`*_ccold` would be labelled `leftover`.
 
 ## References
 
-- [PostgreSQL Documentation: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
-- [PostgreSQL Documentation: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
-- [PostgreSQL Documentation: pg_stat_progress_create_index](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING)
+- [CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
+- [REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)

--- a/docs/checks/invalid-indexes.md
+++ b/docs/checks/invalid-indexes.md
@@ -1,45 +1,74 @@
-# Invalid Indexes Check
+# Invalid Indexes
 
-Finds indexes stuck in an invalid state (`pg_index.indisvalid = false`). The
-planner ignores them, so they cost disk without helping queries.
+Identifies indexes left in an invalid state (`pg_index.indisvalid = false`). The planner ignores invalid indexes, so they cost disk and maintenance without serving any query.
 
-## What it checks
+## What It Checks
 
-Reports each invalid index as **WARN**, classified by `Type`:
+Every invalid index is reported as **WARN** and tagged with a `Type` so you know how to act on it. Indexes a concurrent build is *currently* working on are excluded — they are invalid only until the build finishes.
 
-- **broken** — a `CREATE INDEX CONCURRENTLY` that failed or was interrupted, or
-  any other permanently-invalid index.
-- **leftover** — a `_ccnew`/`_ccold` transient left behind by a failed or
-  cancelled `REINDEX CONCURRENTLY`. The original index is still valid.
+### Broken (`broken`)
+A permanently-invalid index: a `CREATE INDEX CONCURRENTLY` that failed or was interrupted, or any other index PostgreSQL has marked invalid.
 
-Indexes a `CREATE`/`REINDEX INDEX CONCURRENTLY` is *currently* building are
-excluded — they are invalid only until the build finishes (in flight, not
-broken). System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are
-excluded; `cron`/`pgpartman`/`debezium` are not, since an invalid index there is
-a real problem.
+**Severity**: WARN
 
-## How to fix
+**Example**:
+```sql
+CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
+-- interrupted or failed -> idx_users_email stays indisvalid = false
+```
+
+### Abandoned REINDEX leftover (`leftover`)
+A `_ccnew`/`_ccold` transient left behind by a failed or cancelled `REINDEX INDEX CONCURRENTLY`. The original index is still valid and in use, so the leftover is harmless clutter.
+
+**Severity**: WARN
+
+**Example**:
+```sql
+REINDEX INDEX CONCURRENTLY idx_orders_status;
+-- cancelled mid-build -> idx_orders_status_ccnew left behind, invalid
+```
+
+### Excluded: builds in flight
+While a `CREATE INDEX CONCURRENTLY` or `REINDEX INDEX CONCURRENTLY` is running, the new index is invalid until the build completes. These have an active `pg_stat_progress_create_index` row and are excluded — in flight, not broken.
+
+System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are excluded. Unlike duplicate indexes, an invalid index in `cron`/`pgpartman`/`debezium` *is* reported — there, it is a real operational problem.
+
+## Why It Matters
+
+Invalid indexes cause problems:
+
+- **Wasted disk space**: they consume storage but provide no benefit
+- **Query performance**: the planner ignores them, defeating their purpose
+- **Hidden failures**: often a sign of an interrupted migration or operational issue
+- **Confusion**: can mislead developers during query optimization
+
+## How to Fix
+
+### Broken indexes
+Rebuild it (preferred if the index is still wanted) or drop it:
 
 ```sql
--- broken: rebuild, or drop if the index is no longer wanted
 REINDEX INDEX CONCURRENTLY your_schema.your_index;
+-- or, if it is no longer needed:
 DROP INDEX CONCURRENTLY your_schema.your_index;
+```
 
--- leftover: just drop it, the original index is still valid
+Check the PostgreSQL logs for the original failure before rebuilding.
+
+### Abandoned leftovers
+The original index is still valid — just drop the leftover:
+
+```sql
 DROP INDEX CONCURRENTLY your_schema.your_leftover;
 ```
 
-For a broken index, check the PostgreSQL logs for the original failure before
-rebuilding.
+## Important Considerations
 
-## Notes
-
-- On a read replica, an in-flight build on the primary can briefly show its
-  `_ccnew` as a leftover (`pg_stat_progress_create_index` is local-only); it
-  clears once the build replays.
-- A user index literally named `*_ccnew`/`*_ccold` would be labelled `leftover`.
+- **Read replicas**: on a standby, an in-flight build on the primary can briefly show its `_ccnew` as a `leftover` — `pg_stat_progress_create_index` reflects local backends only. It clears once the build replays.
+- **Naming collisions**: a user index literally named `*_ccnew`/`*_ccold` that is genuinely invalid would be tagged `leftover` rather than `broken`. Rare, and only affects the label.
 
 ## References
 
-- [CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
-- [REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
+- [PostgreSQL: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
+- [PostgreSQL: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
+- [PostgreSQL: pg_stat_progress_create_index](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING)

--- a/docs/checks/invalid-indexes.md
+++ b/docs/checks/invalid-indexes.md
@@ -1,48 +1,78 @@
 # Invalid Indexes Check
 
-Identifies PostgreSQL indexes that are in an invalid state and not being used by the query planner.
+Identifies PostgreSQL indexes that are in an invalid state (`pg_index.indisvalid = false`)
+and not used by the query planner — while ignoring indexes that are merely being
+built right now.
 
 ## What it checks
 
-- Indexes marked as invalid in `pg_index.indisvalid`
-- Indexes that failed during concurrent creation or reindexing
-- Orphaned invalid indexes taking up disk space
+An index ends up `indisvalid = false` for one of three reasons, and this check
+treats each differently:
+
+1. **In-flight build (silently ignored).** While a `CREATE INDEX CONCURRENTLY` or
+   `REINDEX INDEX CONCURRENTLY` is running, the new index is invalid until the
+   build completes. The check excludes any index that has an active
+   `pg_stat_progress_create_index` row, because it is in flight, not broken.
+
+2. **Broken index → FAIL.** A genuinely-broken index (`is_leftover = false`): a
+   `CREATE INDEX CONCURRENTLY` that failed or was interrupted, leaving a permanent
+   invalid index that the planner ignores. Reported under the `broken-indexes`
+   subcheck as **FAIL** when any exist.
+
+3. **Abandoned REINDEX leftover → WARN.** A `_ccnew`/`_ccold` transient
+   (`is_leftover = true`) left behind by a failed or cancelled
+   `REINDEX CONCURRENTLY`. The original index is still valid, so these are
+   non-urgent clutter. Reported under the `abandoned-leftovers` subcheck as
+   **WARN** when any exist.
+
+Both subchecks are always emitted: each reports `OK` when its class is empty.
+The overall check severity is the maximum across the two findings.
+
+System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are excluded. An
+invalid index in `cron`/`pgpartman`/`debezium` is intentionally *not* excluded —
+unlike a duplicate index, an invalid index there is a real operational problem.
 
 ## Why it matters
 
 Invalid indexes cause problems:
+
 - **Wasted disk space**: Invalid indexes consume storage but provide no benefit
 - **Query performance**: Not used by the query planner, defeating their purpose
 - **Hidden failures**: May indicate underlying data quality or operational issues
 - **Confusion**: Can mislead developers during query optimization
 
-An index becomes invalid when:
-- `CREATE INDEX CONCURRENTLY` fails or is interrupted
-- `REINDEX CONCURRENTLY` encounters an error
-- Data doesn't satisfy the index conditions
-
 ## How to Fix
 
-For each invalid index, choose one of these options:
+### Broken indexes (FAIL)
 
-### Option 1: Recreate the Index
+For each broken index, choose one of:
+
+**Rebuild the index** (preferred when the index is still wanted):
 
 ```sql
-REINDEX INDEX CONCURRENTLY your_index_name;
+REINDEX INDEX CONCURRENTLY your_schema.your_index_name;
 ```
 
-**Before recreating:**
+**Drop the index** (if it is no longer needed):
+
+```sql
+DROP INDEX CONCURRENTLY your_schema.your_index_name;
+```
+
+Before rebuilding:
+
 1. Investigate why the index failed initially
 2. Check for locking issues or timeout problems
 3. Verify the underlying data satisfies the index conditions
 4. Consider if the index definition needs modification
 
-### Option 2: Drop the Index
+### Abandoned REINDEX leftovers (WARN)
 
-If the index is no longer needed:
+The original index is still valid; the `_ccnew`/`_ccold` leftover can simply be
+dropped:
 
 ```sql
-DROP INDEX CONCURRENTLY your_index_name;
+DROP INDEX CONCURRENTLY your_schema.your_leftover_index;
 ```
 
 ### Investigation Steps
@@ -51,14 +81,27 @@ DROP INDEX CONCURRENTLY your_index_name;
    ```sql
    SELECT indexdef FROM pg_indexes WHERE indexname = 'your_index_name';
    ```
-
 2. **Review PostgreSQL logs** for errors during index creation
-
-3. **Verify data integrity** - ensure data meets index constraints
-
+3. **Verify data integrity** — ensure data meets index constraints
 4. **Check for lock conflicts** that might have interrupted creation
+
+## Notes / caveats
+
+- **Read replicas.** On a standby, an in-flight build on the primary can briefly
+  surface its `_ccnew` index as a WARN: the standby sees the invalid index but
+  `pg_stat_progress_create_index` reflects only local backends, so the in-flight
+  exclusion does not apply. It clears once the primary finishes and the change
+  replays.
+- **Naming collisions.** A user index literally named `*_ccnew`/`*_ccold` that is
+  genuinely invalid would be classified as a WARN leftover rather than a FAIL.
+  This is rare and only affects severity, not detection.
+- **Classification can change between runs.** Whether a given `_ccnew` index is
+  reported (and as what) can change from one run to the next as a concurrent
+  reindex makes progress, completes, or its backend dies and leaves the transient
+  behind.
 
 ## References
 
 - [PostgreSQL Documentation: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
 - [PostgreSQL Documentation: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
+- [PostgreSQL Documentation: pg_stat_progress_create_index](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING)

--- a/docs/checks/invalid-indexes.md
+++ b/docs/checks/invalid-indexes.md
@@ -1,74 +1,67 @@
-# Invalid Indexes
+# Invalid Indexes Check
 
-Identifies indexes left in an invalid state (`pg_index.indisvalid = false`). The planner ignores invalid indexes, so they cost disk and maintenance without serving any query.
+Identifies PostgreSQL indexes that are in an invalid state and not being used by the query planner.
 
-## What It Checks
+## What it checks
 
-Every invalid index is reported as **WARN** and tagged with a `Type` so you know how to act on it. Indexes a concurrent build is *currently* working on are excluded — they are invalid only until the build finishes.
+- Indexes marked as invalid in `pg_index.indisvalid`
+- Indexes that failed during concurrent creation or reindexing
+- Orphaned invalid indexes taking up disk space
+- Abandoned `_ccnew`/`_ccold` leftovers from a cancelled `REINDEX CONCURRENTLY` (tagged `leftover` — safe to drop)
 
-### Broken (`broken`)
-A permanently-invalid index: a `CREATE INDEX CONCURRENTLY` that failed or was interrupted, or any other index PostgreSQL has marked invalid.
+Indexes a live `CREATE`/`REINDEX INDEX CONCURRENTLY` is still building are excluded — they are invalid only until the build finishes.
 
-**Severity**: WARN
-
-**Example**:
-```sql
-CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
--- interrupted or failed -> idx_users_email stays indisvalid = false
-```
-
-### Abandoned REINDEX leftover (`leftover`)
-A `_ccnew`/`_ccold` transient left behind by a failed or cancelled `REINDEX INDEX CONCURRENTLY`. The original index is still valid and in use, so the leftover is harmless clutter.
-
-**Severity**: WARN
-
-**Example**:
-```sql
-REINDEX INDEX CONCURRENTLY idx_orders_status;
--- cancelled mid-build -> idx_orders_status_ccnew left behind, invalid
-```
-
-### Excluded: builds in flight
-While a `CREATE INDEX CONCURRENTLY` or `REINDEX INDEX CONCURRENTLY` is running, the new index is invalid until the build completes. These have an active `pg_stat_progress_create_index` row and are excluded — in flight, not broken.
-
-System schemas (`pg_catalog`, `information_schema`, `pg_toast`) are excluded. Unlike duplicate indexes, an invalid index in `cron`/`pgpartman`/`debezium` *is* reported — there, it is a real operational problem.
-
-## Why It Matters
+## Why it matters
 
 Invalid indexes cause problems:
+- **Wasted disk space**: Invalid indexes consume storage but provide no benefit
+- **Query performance**: Not used by the query planner, defeating their purpose
+- **Hidden failures**: May indicate underlying data quality or operational issues
+- **Confusion**: Can mislead developers during query optimization
 
-- **Wasted disk space**: they consume storage but provide no benefit
-- **Query performance**: the planner ignores them, defeating their purpose
-- **Hidden failures**: often a sign of an interrupted migration or operational issue
-- **Confusion**: can mislead developers during query optimization
+An index becomes invalid when:
+- `CREATE INDEX CONCURRENTLY` fails or is interrupted
+- `REINDEX CONCURRENTLY` encounters an error
+- Data doesn't satisfy the index conditions
 
 ## How to Fix
 
-### Broken indexes
-Rebuild it (preferred if the index is still wanted) or drop it:
+For each invalid index, choose one of these options:
+
+### Option 1: Recreate the Index
 
 ```sql
-REINDEX INDEX CONCURRENTLY your_schema.your_index;
--- or, if it is no longer needed:
-DROP INDEX CONCURRENTLY your_schema.your_index;
+REINDEX INDEX CONCURRENTLY your_index_name;
 ```
 
-Check the PostgreSQL logs for the original failure before rebuilding.
+**Before recreating:**
+1. Investigate why the index failed initially
+2. Check for locking issues or timeout problems
+3. Verify the underlying data satisfies the index conditions
+4. Consider if the index definition needs modification
 
-### Abandoned leftovers
-The original index is still valid — just drop the leftover:
+### Option 2: Drop the Index
+
+If the index is no longer needed:
 
 ```sql
-DROP INDEX CONCURRENTLY your_schema.your_leftover;
+DROP INDEX CONCURRENTLY your_index_name;
 ```
 
-## Important Considerations
+### Investigation Steps
 
-- **Read replicas**: on a standby, an in-flight build on the primary can briefly show its `_ccnew` as a `leftover` — `pg_stat_progress_create_index` reflects local backends only. It clears once the build replays.
-- **Naming collisions**: a user index literally named `*_ccnew`/`*_ccold` that is genuinely invalid would be tagged `leftover` rather than `broken`. Rare, and only affects the label.
+1. **Check index definition:**
+   ```sql
+   SELECT indexdef FROM pg_indexes WHERE indexname = 'your_index_name';
+   ```
+
+2. **Review PostgreSQL logs** for errors during index creation
+
+3. **Verify data integrity** - ensure data meets index constraints
+
+4. **Check for lock conflicts** that might have interrupted creation
 
 ## References
 
-- [PostgreSQL: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
-- [PostgreSQL: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)
-- [PostgreSQL: pg_stat_progress_create_index](https://www.postgresql.org/docs/current/progress-reporting.html#CREATE-INDEX-PROGRESS-REPORTING)
+- [PostgreSQL Documentation: CREATE INDEX](https://www.postgresql.org/docs/current/sql-createindex.html)
+- [PostgreSQL Documentation: REINDEX](https://www.postgresql.org/docs/current/sql-reindex.html)


### PR DESCRIPTION
Closes #12.

## Problem
`invalidindexes` flagged **every** `NOT pg_index.indisvalid` index as a single WARN. Two issues:
1. **False positives for in-progress builds** — an index a live `CREATE INDEX CONCURRENTLY` / `REINDEX INDEX CONCURRENTLY` is building is `indisvalid = false` until it finishes. Not broken, just in flight.
2. **No classification** — a failed/cancelled `REINDEX CONCURRENTLY` leaves `_ccnew`/`_ccold` invalid leftovers (the original stays valid). These are truly abandoned and droppable, but looked identical to genuinely-broken indexes.

## Change
- **Exclude in-flight builds** via `NOT EXISTS` against `pg_stat_progress_create_index`. During both `CREATE` and `REINDEX INDEX CONCURRENTLY`, `index_relid` points to the new (invalid) index OID, so an active progress row means "in flight, not broken" — source-verified against PG15/16 `ReindexRelationConcurrently` (`newidx->indexId` during build + validate phases).
- **Classify** remaining invalid indexes into two subchecks:
  | Finding | Indexes | Severity | Fix |
  |---|---|---|---|
  | `broken-indexes` | genuinely broken real indexes | **FAIL** | `REINDEX INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` |
  | `abandoned-leftovers` | `_ccnew`/`_ccold` REINDEX transients | **WARN** | `DROP INDEX CONCURRENTLY` |
- **Narrow the schema-exclusion list** to system schemas only (`pg_catalog`, `information_schema`, `pg_toast`). Unlike `duplicateindexes`, an *invalid* index in `cron`/`pgpartman`/`debezium` is a real operational problem worth surfacing.

## SQL
\`\`\`sql
WHERE NOT i.indisvalid
  AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
  AND NOT EXISTS (
    SELECT 1 FROM pg_stat_progress_create_index AS p
    WHERE p.index_relid = i.indexrelid
  )
\`\`\`
Read-only, system catalogs only, no locks/writes; `pg_stat_progress_create_index` is a cheap in-memory view. Targets PG15+ (view exists since PG12).

## Caveats (documented in the check README)
- On a read replica, an in-flight build on the primary can briefly surface its `_ccnew` as a WARN.
- A user index literally named `*_ccnew`/`*_ccold` that is genuinely invalid would be classed WARN, not FAIL (rare).
- Classification of a given `_ccnew` can change between runs as a concurrent reindex progresses or its backend dies.

## Notes
- `db/query.sql.go` was hand-edited to match sqlc v1.30.0 output (no Postgres available locally to run `sqlc generate`). CI doesn't re-run sqlc; `go build`/`go test` cover correctness.
- `go generate ./...` produces no drift. Local verification: `gofmt -l` clean, `go vet` clean, `go build ./...` clean, `go test -race ./...` green.