### PR TITLE
chore: changelog for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-01
+
+### Added
+
+- **`invalid-indexes`**: classifies abandoned `_ccnew`/`_ccold` leftovers from a cancelled `REINDEX CONCURRENTLY` as a droppable `leftover`, distinct from genuinely-broken indexes (shown via a `Type` column).
+- **`replication-lag`**: capacity-relative signal for logical slots — compares the backlog against `max_slot_wal_keep_size` (≥50% warn, ≥85% fail), firing before Postgres flips `wal_status` to `unreserved`. Disabled when the cap is unlimited (`-1`, the RDS default).
+- **`check.ParseDurationMs`**: exported helper that parses GUC duration values (`2000ms`, `2s`, `1min`, `1.5s`, bare numbers, `-1`/`0` sentinels) to milliseconds.
+
+### Changed
+
+- **`invalid-indexes`**: excludes indexes a live `CREATE`/`REINDEX INDEX CONCURRENTLY` is still building (they are invalid only until the build completes), removing false positives during concurrent builds.
+- **`session-settings`**: encodes the full `pg_db_role_setting` precedence (`role+db > role > db > ALTER ROLE ALL > reset_val`), so the reported value matches what a role actually gets on connect.
+- **`connection-health`** idle ratio: now advisory — warns at ≥90% idle with no FAIL tier (genuine exhaustion is already covered by `connection-saturation` and `pool-pressure`).
+- **`replication-lag`** (logical): WARN/FAIL now require both sustained lag time **and** a material backlog (≥120s + ≥550 MiB to warn; ≥300s + ≥2 GiB to fail), so Debezium's ack cadence alone no longer trips alerts. Physical replication unchanged.
+
+### Fixed
+
+- **`session-settings`**: unit-aware parsing of timeout values like `2000ms`/`1min` that previously crashed and skipped the entire check; `transaction_timeout` (PG17+) is now skipped on older versions instead of reporting a false `MUST be set` failure.
+- **`--detail debug`**: renders `Finding.Debug` for single-finding checks (previously only shown for multi-finding checks).
+
+### Removed
+
+- Orphaned `MissingProviderIdTables` generated query (no corresponding check existed).
+
 ## [0.2.0] - 2026-04-05
 
 ### Added


### PR DESCRIPTION
Rolls up everything merged since **v0.2.0** into a `0.3.0` CHANGELOG section.

## ⚠️ Merging this cuts the release
`auto-tag.yml` triggers on any `CHANGELOG.md` change to `master`: it reads the top dated heading (`## [0.3.0] - 2026-06-01`), pushes tag **`v0.3.0`**, and runs GoReleaser. So **merge = release**. If you want a different version, change the heading before merging.

## Why 0.3.0 (minor, not 0.2.1)
Pre-1.0, minor bumps for new capability/behavior. This batch adds a new `invalid-indexes` classification + in-flight exclusion, a new capacity-relative `replication-lag` signal, and a new exported `check.ParseDurationMs` — plus correctness fixes. Consistent with the 0.1.0 → 0.2.0 bump.

## Contents (since v0.2.0)
- **#13 / #12** — `invalid-indexes`: exclude in-flight concurrent builds, classify `_ccnew`/`_ccold` leftovers
- **#11** — `--detail debug` renders `Finding.Debug` for single-finding checks
- **#10** — `session-settings` correctness (precedence + unit parsing + PG17 gating), idle-ratio downgraded to advisory, `replication-lag` capacity-aware
- `#14` (docs-only) intentionally omitted

Docs PR for AGENTS.md presets (#14) is excluded as a non-user-facing change.