### PR TITLE
feat(check): add SeverityInfo severity level

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ pgdoctor.ValidateFilters(checks, filters) (valid, invalid []string)
 report.AddFinding(check.Finding{
     ID:       "specific-validation",
     Name:     "Human-readable name",
-    Severity: check.SeverityFail,    // OK|Warn|Fail
+    Severity: check.SeverityFail,    // Info|OK|Warn|Fail
     Details:  "What's wrong",
     Table:    &check.Table{...},     // Optional structured data
     Debug:    "Debug info",          // Only shown with --detail debug
@@ -287,12 +287,13 @@ Five categories:
 
 ### Severity
 
+- `check.SeverityInfo` - Relevant information, no action expected
 - `check.SeveritySkip` - Check could not run (timeout, permission error)
 - `check.SeverityOK` - Check passed, no action needed
 - `check.SeverityWarn` - Issue found, non-urgent action
 - `check.SeverityFail` - Issue found, urgent action required
 
-Report severity is automatically the maximum across all findings. `SeveritySkip` is ordered below `SeverityOK` so it doesn't affect severity comparisons.
+Report severity is automatically the maximum across all findings. `SeverityInfo` and `SeveritySkip` are ordered below `SeverityOK` so they don't affect severity comparisons.
 
 ### Presets
 
@@ -474,6 +475,7 @@ Each contrib check creates its own sqlc queries internally, using the `check.DBT
 |----------|------------|---------|
 | FAIL | Data loss risk, security issue, imminent outage | No backups, publicly accessible, sequence at 90%+ |
 | WARN | Should fix but not urgent, performance degradation | Old storage type, high bloat, outdated minor version |
+| INFO | Relevant information with no expected action | Correct-by-design states, contextual-judgment calls |
 | OK | Everything is fine | Always report at least one OK finding per check |
 
 **Rule of thumb:** If a DBA would page someone at 3am, it's a FAIL. If it should go in the sprint backlog, it's a WARN.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **check**: new `SeverityInfo` level (below `SeverityOK`) for informational findings that must never escalate a report. Consumers switching over `Severity` with a `default` branch will silently bucket INFO there until they add an explicit case — audit before surfacing INFO.
+
 ### Changed
 
 - **`cache-efficiency`**: now a non-paging advisory — dropped the FAIL tier and lowered the OK threshold to ≥90% (WARN only below 90%). The 90-95% band is dominated by OS-page-cache reads that Postgres counts as `blks_read`, so it was near-constant noise on healthy OLTP instances; genuine memory pressure surfaces in read latency / IOPS, not the global hit ratio.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,7 @@ Choose severity carefully — it determines how users prioritize their work:
 
 - **FAIL**: Requires action. Security risk, data loss potential, or imminent outage.
 - **WARN**: Should address. Performance issue, technical debt, or best practice violation.
+- **INFO**: Worth knowing. Relevant information with no expected action; never escalates the report severity.
 - **OK**: Passing. Always include at least one OK finding when no issues are detected.
 
 When in doubt, prefer WARN over FAIL. A noisy tool that cries wolf loses trust.

--- a/check/check.go
+++ b/check/check.go
@@ -16,14 +16,18 @@ type DBTX = db.DBTX
 type Severity int
 
 const (
-	SeveritySkip Severity = iota - 1 // Check could not run (timeout, permission error, etc.)
-	SeverityOK   Severity = iota
-	SeverityWarn
-	SeverityFail
+	SeverityInfo Severity = -2 // Informational; never escalates a report's severity
+	SeveritySkip Severity = -1 // Check could not run (timeout, permission error, etc.)
+	// 0 is intentionally unused: the zero value means "unset" and renders as "unknown".
+	SeverityOK   Severity = 1
+	SeverityWarn Severity = 2
+	SeverityFail Severity = 3
 )
 
 func (s Severity) String() string {
 	switch s {
+	case SeverityInfo:
+		return "info"
 	case SeverityOK:
 		return "pass"
 	case SeverityWarn:

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -1,0 +1,46 @@
+package check_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/emancu/pgdoctor/check"
+)
+
+// Severity values are part of the public API: consumers compare and persist
+// them, so renumbering is a breaking change even if names stay the same.
+func TestSeverity_Values(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, check.Severity(-2), check.SeverityInfo)
+	require.Equal(t, check.Severity(-1), check.SeveritySkip)
+	require.Equal(t, check.Severity(1), check.SeverityOK)
+	require.Equal(t, check.Severity(2), check.SeverityWarn)
+	require.Equal(t, check.Severity(3), check.SeverityFail)
+}
+
+func TestSeverity_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		severity check.Severity
+		expect   string
+	}{
+		{name: "info", severity: check.SeverityInfo, expect: "info"},
+		{name: "skip", severity: check.SeveritySkip, expect: "skip"},
+		{name: "ok", severity: check.SeverityOK, expect: "pass"},
+		{name: "warn", severity: check.SeverityWarn, expect: "warn"},
+		{name: "fail", severity: check.SeverityFail, expect: "fail"},
+		{name: "zero value is unset", severity: check.Severity(0), expect: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expect, tt.severity.String())
+		})
+	}
+}

--- a/checks/README.md
+++ b/checks/README.md
@@ -359,6 +359,20 @@ report.AddFinding(check.Finding{
 })
 ```
 
+## Severity Criteria
+
+Pick the severity by what you expect the reader to do with the finding:
+
+- **FAIL** - Imminent incident risk (hours/days), with one specific corrective action. Must not be a false positive by construction: no unguarded point-in-time snapshots or cumulative-since-stats-reset counters.
+- **WARN** - Clear corrective action for a chronic risk or resource waste. Tolerates workload-dependent signals or age-gated counters.
+- **INFO** - Relevant information with no expected action: correct-by-design states, contextual-judgment calls, or structurally confounded metrics. INFO never escalates the report severity, and renderers may hide it by default.
+- **OK** - The check ran and found nothing above threshold.
+- **SKIP** - The check could not run (timeout, permission error).
+
+When in doubt, downgrade — false alarms cost more trust than a missed WARN.
+
+Row severity must never exceed its finding's severity (enforced by `internal/checktest.AssertSeverityInvariant`).
+
 ## CLI Output Format
 
 The CLI displays checks grouped by category:

--- a/checks/sessionsettings/check_test.go
+++ b/checks/sessionsettings/check_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/sessionsettings"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/emancu/pgdoctor/internal/checktest"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
@@ -252,6 +253,7 @@ func Test_SessionSettings(t *testing.T) {
 			checker := sessionsettings.New(queryer)
 			report, err := checker.Check(context.Background())
 			require.NoError(t, err)
+			checktest.AssertSeverityInvariant(t, report)
 
 			results := report.Results
 			require.Equal(t, 1, len(results), "Should have exactly 1 result")
@@ -292,6 +294,7 @@ func Test_SessionSettings_MultipleIssues(t *testing.T) {
 	checker := sessionsettings.New(queryer)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	results := report.Results
 	require.Equal(t, 1, len(results), "Should have exactly 1 result")
@@ -328,6 +331,7 @@ func Test_SessionSettings_BothRolesCheckedEqually(t *testing.T) {
 	checker := sessionsettings.New(queryer)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	results := report.Results
 	require.Equal(t, 1, len(results), "Should have exactly 1 result")
@@ -404,6 +408,7 @@ func Test_SessionSettings_SpecificDetailChecks(t *testing.T) {
 			checker := sessionsettings.New(queryer)
 			report, err := checker.Check(context.Background())
 			require.NoError(t, err)
+			checktest.AssertSeverityInvariant(t, report)
 
 			results := report.Results
 			require.Equal(t, 1, len(results), "Should have exactly 1 result")
@@ -437,6 +442,7 @@ func Test_SessionSettings_EmptyRoles(t *testing.T) {
 	checker := sessionsettings.New(queryer)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	results := report.Results
 	require.Equal(t, 1, len(results), "Should have exactly 1 result")
@@ -469,6 +475,7 @@ func Test_SessionSettings_ArbitraryRoleNames(t *testing.T) {
 	checker := sessionsettings.New(queryer)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	results := report.Results
 	require.Equal(t, 1, len(results), "Should have exactly 1 result")
@@ -496,6 +503,7 @@ func Test_SessionSettings_ConfiguredRoleMissing(t *testing.T) {
 	checker := sessionsettings.New(queryer, cfg)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	results := report.Results
 	require.Equal(t, 1, len(results), "Should have exactly 1 result")
@@ -541,6 +549,7 @@ func Test_SessionSettings_CustomThresholds_Warn(t *testing.T) {
 	checker := sessionsettings.New(queryer, cfg)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	result := report.Results[0]
 	require.Equal(t, check.SeverityWarn, result.Severity, "3000ms should WARN when threshold is 2000")
@@ -583,6 +592,7 @@ func Test_SessionSettings_CustomThresholds_Fail(t *testing.T) {
 	checker := sessionsettings.New(queryer, cfg)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	result := report.Results[0]
 	require.Equal(t, check.SeverityFail, result.Severity, "7000ms should FAIL when threshold is 5000")
@@ -616,6 +626,7 @@ func Test_SessionSettings_DefaultThresholds(t *testing.T) {
 	checker := sessionsettings.New(queryer)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	result := report.Results[0]
 	require.Equal(t, check.SeverityWarn, result.Severity, "7000ms should WARN with default thresholds (5000/10000)")
@@ -655,6 +666,7 @@ func Test_SessionSettings_ConfigOverridesDiscovery(t *testing.T) {
 	checker := sessionsettings.New(queryer, cfg)
 	report, err := checker.Check(context.Background())
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 
 	results := report.Results
 	require.Equal(t, 1, len(results), "Should have exactly 1 result")

--- a/checks/uuiddefaults/check_test.go
+++ b/checks/uuiddefaults/check_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/emancu/pgdoctor/check"
 	"github.com/emancu/pgdoctor/checks/uuiddefaults"
 	"github.com/emancu/pgdoctor/db"
+	"github.com/emancu/pgdoctor/internal/checktest"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
@@ -43,6 +44,7 @@ func Test_UUIDDefaults_NoIssues(t *testing.T) {
 	report, err := checker.Check(context.Background())
 
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 	require.Equal(t, check.SeverityOK, report.Severity)
 	require.Equal(t, 1, len(report.Results))
 	require.Contains(t, report.Results[0].Details, "No indexed UUID")
@@ -61,6 +63,7 @@ func Test_UUIDDefaults_NoIndex(t *testing.T) {
 	report, err := checker.Check(context.Background())
 
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 	require.Equal(t, check.SeverityOK, report.Severity)
 }
 
@@ -77,6 +80,7 @@ func Test_UUIDDefaults_NotRandomUUID(t *testing.T) {
 	report, err := checker.Check(context.Background())
 
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 	require.Equal(t, check.SeverityOK, report.Severity)
 }
 
@@ -93,6 +97,7 @@ func Test_UUIDDefaults_RandomUUIDIndexed(t *testing.T) {
 	report, err := checker.Check(context.Background())
 
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 	require.Equal(t, check.SeverityWarn, report.Severity)
 	require.Equal(t, 1, len(report.Results))
 	require.Contains(t, report.Results[0].Details, "Found 1 indexed UUID column")
@@ -113,6 +118,7 @@ func Test_UUIDDefaults_UUIDGenerateV4(t *testing.T) {
 	report, err := checker.Check(context.Background())
 
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 	require.Equal(t, check.SeverityWarn, report.Severity)
 	require.Equal(t, 1, len(report.Results))
 	require.Contains(t, report.Results[0].Details, "random v4 defaults")
@@ -133,6 +139,7 @@ func Test_UUIDDefaults_Multiple(t *testing.T) {
 	report, err := checker.Check(context.Background())
 
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 	require.Equal(t, check.SeverityWarn, report.Severity)
 	require.Contains(t, report.Results[0].Details, "Found 3 indexed UUID column")
 	require.NotNil(t, report.Results[0].Table)
@@ -180,6 +187,7 @@ func Test_UUIDDefaults_PrescriptionContent(t *testing.T) {
 	report, err := checker.Check(context.Background())
 
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 	require.Equal(t, 1, len(report.Results))
 }
 
@@ -197,6 +205,7 @@ func Test_UUIDDefaults_TableFormatting(t *testing.T) {
 	report, err := checker.Check(context.Background())
 
 	require.NoError(t, err)
+	checktest.AssertSeverityInvariant(t, report)
 	require.Equal(t, 1, len(report.Results))
 	require.NotNil(t, report.Results[0].Table)
 
@@ -265,6 +274,7 @@ func Test_UUIDDefaults_FilteringLogic(t *testing.T) {
 			report, err := checker.Check(context.Background())
 
 			require.NoError(t, err)
+			checktest.AssertSeverityInvariant(t, report)
 			require.Equal(t, tt.expectedSeverity, report.Severity)
 			if tt.expectedCount > 0 {
 				require.NotNil(t, report.Results[0].Table)

--- a/internal/checktest/checktest.go
+++ b/internal/checktest/checktest.go
@@ -1,0 +1,55 @@
+// Package checktest provides shared assertions for check unit tests.
+package checktest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/emancu/pgdoctor/check"
+)
+
+// AssertSeverityInvariant verifies the severity contract established by
+// check.NewReport and check.Report.AddFinding: the report severity is the
+// maximum finding severity (never below SeverityOK), and no table row is
+// more severe than the finding that contains it.
+//
+// It covers reports built through AddFinding; runner-injected SKIP reports
+// set Report.Severity directly and are outside this contract.
+func AssertSeverityInvariant(t *testing.T, report *check.Report) {
+	t.Helper()
+
+	for _, violation := range severityViolations(report) {
+		t.Error(violation)
+	}
+}
+
+func severityViolations(report *check.Report) []string {
+	var violations []string
+
+	want := check.SeverityOK
+	for _, finding := range report.Results {
+		if finding.Severity > want {
+			want = finding.Severity
+		}
+	}
+	if report.Severity != want {
+		violations = append(violations, fmt.Sprintf(
+			"report %q severity is %q, want %q (max finding severity, floored at %q)",
+			report.CheckID, report.Severity, want, check.SeverityOK))
+	}
+
+	for _, finding := range report.Results {
+		if finding.Table == nil {
+			continue
+		}
+		for i, row := range finding.Table.Rows {
+			if row.Severity > finding.Severity {
+				violations = append(violations, fmt.Sprintf(
+					"finding %q row %d severity %q exceeds finding severity %q",
+					finding.ID, i, row.Severity, finding.Severity))
+			}
+		}
+	}
+
+	return violations
+}

--- a/internal/checktest/checktest_test.go
+++ b/internal/checktest/checktest_test.go
@@ -1,0 +1,140 @@
+// White-box on purpose: violating reports are asserted through
+// severityViolations, since feeding them to AssertSeverityInvariant would
+// fail the test run itself.
+package checktest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/emancu/pgdoctor/check"
+)
+
+func metadata() check.Metadata {
+	return check.Metadata{
+		CheckID:  "sample-check",
+		Name:     "Sample Check",
+		Category: check.CategoryConfigs,
+	}
+}
+
+func reportWith(findings ...check.Finding) *check.Report {
+	report := check.NewReport(metadata())
+	for _, finding := range findings {
+		report.AddFinding(finding)
+	}
+	return report
+}
+
+func TestAssertSeverityInvariant_Passing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		report *check.Report
+	}{
+		{
+			name:   "single OK finding",
+			report: reportWith(check.Finding{ID: "sample-check", Severity: check.SeverityOK}),
+		},
+		{
+			name: "info finding with info rows keeps report at OK",
+			report: reportWith(check.Finding{
+				ID:       "informational",
+				Severity: check.SeverityInfo,
+				Table: &check.Table{
+					Headers: []string{"Item"},
+					Rows: []check.TableRow{
+						{Cells: []string{"a"}, Severity: check.SeverityInfo},
+						{Cells: []string{"b"}, Severity: check.SeverityInfo},
+					},
+				},
+			}),
+		},
+		{
+			name: "warn finding with mixed rows at or below warn",
+			report: reportWith(
+				check.Finding{ID: "healthy", Severity: check.SeverityOK},
+				check.Finding{
+					ID:       "chronic",
+					Severity: check.SeverityWarn,
+					Table: &check.Table{
+						Headers: []string{"Item"},
+						Rows: []check.TableRow{
+							{Cells: []string{"a"}, Severity: check.SeverityOK},
+							{Cells: []string{"b"}, Severity: check.SeverityWarn},
+						},
+					},
+				},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			AssertSeverityInvariant(t, tt.report)
+			require.Empty(t, severityViolations(tt.report))
+		})
+	}
+}
+
+func TestSeverityViolations(t *testing.T) {
+	t.Parallel()
+
+	understatedReport := reportWith(check.Finding{ID: "issue", Severity: check.SeverityWarn})
+	understatedReport.Severity = check.SeverityOK
+
+	tests := []struct {
+		name   string
+		report *check.Report
+		expect []string
+	}{
+		{
+			name:   "report severity below max finding severity",
+			report: understatedReport,
+			expect: []string{`report "sample-check" severity is "pass", want "warn"`},
+		},
+		{
+			name: "row severity exceeds its finding",
+			report: reportWith(check.Finding{
+				ID:       "overstated-rows",
+				Severity: check.SeverityWarn,
+				Table: &check.Table{
+					Headers: []string{"Item"},
+					Rows: []check.TableRow{
+						{Cells: []string{"a"}, Severity: check.SeverityWarn},
+						{Cells: []string{"b"}, Severity: check.SeverityFail},
+					},
+				},
+			}),
+			expect: []string{`finding "overstated-rows" row 1 severity "fail" exceeds finding severity "warn"`},
+		},
+		{
+			name: "info finding with warn row",
+			report: reportWith(check.Finding{
+				ID:       "informational",
+				Severity: check.SeverityInfo,
+				Table: &check.Table{
+					Headers: []string{"Item"},
+					Rows:    []check.TableRow{{Cells: []string{"a"}, Severity: check.SeverityWarn}},
+				},
+			}),
+			expect: []string{`finding "informational" row 0 severity "warn" exceeds finding severity "info"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			violations := severityViolations(tt.report)
+			require.Len(t, violations, len(tt.expect))
+			for i, expect := range tt.expect {
+				require.Contains(t, violations[i], expect)
+			}
+		})
+	}
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -212,7 +212,7 @@ func printTable(w io.Writer, table *check.Table, indentSpaces int, opts *runOpti
 }
 
 func printSummary(w io.Writer, reports []*check.Report) {
-	okCount, warnCount, failCount, skipCount := 0, 0, 0, 0
+	okCount, warnCount, failCount, skipCount, infoCount := 0, 0, 0, 0, 0
 	var totalDuration time.Duration
 	for _, report := range reports {
 		totalDuration += report.Duration
@@ -225,6 +225,8 @@ func printSummary(w io.Writer, reports []*check.Report) {
 			failCount++
 		case check.SeveritySkip:
 			skipCount++
+		case check.SeverityInfo:
+			infoCount++
 		}
 	}
 
@@ -240,6 +242,9 @@ func printSummary(w io.Writer, reports []*check.Report) {
 	if okCount > 0 {
 		summaryParts = append(summaryParts, colorForSeverity(check.SeverityOK)(fmt.Sprintf("%d passed", okCount)))
 	}
+	if infoCount > 0 {
+		summaryParts = append(summaryParts, colorForSeverity(check.SeverityInfo)(fmt.Sprintf("%d info", infoCount)))
+	}
 	if skipCount > 0 {
 		summaryParts = append(summaryParts, colorForSeverity(check.SeveritySkip)(fmt.Sprintf("%d skipped", skipCount)))
 	}
@@ -252,6 +257,8 @@ func printSummary(w io.Writer, reports []*check.Report) {
 
 func severityDisplay(severity check.Severity) (string, func(string) string) {
 	switch severity {
+	case check.SeverityInfo:
+		return "INFO", colorForSeverity(severity)
 	case check.SeverityOK:
 		return "PASS", colorForSeverity(severity)
 	case check.SeverityWarn:
@@ -269,6 +276,9 @@ func colorForSeverity(severity check.Severity) func(string) string {
 	}
 
 	switch severity {
+	case check.SeverityInfo:
+		fn := color.New(color.Faint).SprintFunc()
+		return func(s string) string { return fn(s) }
 	case check.SeverityOK:
 		fn := color.New(color.FgGreen).SprintFunc()
 		return func(s string) string { return fn(s) }


### PR DESCRIPTION
## Summary

Adds a new `SeverityInfo` level for findings that carry relevant information but expect no action — the shared foundation for re-tiering noisy WARN findings (fleet evidence: several findings WARN on 58–99% of 120 production databases, which makes WARN wallpaper).

- **`check.SeverityInfo = -2`** — below `SeverityOK`, so it can never escalate `Report.Severity` (running max), the exit code, or any consumer's fail/warn buckets. All existing constant values are untouched; the iota block is replaced with explicit values and the intentionally-unused `0` gap ("unset"/"unknown") is documented.
- **Severity criteria** documented in `checks/README.md` (new section), `AGENTS.md` (severity list + assignment guide), and `CONTRIBUTING.md` (philosophy list): FAIL = imminent risk + one specific fix + not false-positive-by-construction; WARN = clear fix, chronic/workload-dependent; INFO = no expected action; when in doubt, downgrade.
- **`internal/checktest.AssertSeverityInvariant`** — shared test helper enforcing report severity == max(OK, findings) and row severity ≤ finding severity; wired into `uuiddefaults` and `sessionsettings` tests as the reference pattern. Also works at row level: `TableRow.Severity = Info` marks rows renderers may hide at low detail.
- **`internal/cli`**: explicit INFO cases (faint "INFO" label, summary bucket). Defensive only — no check emits INFO yet; re-tiering follows in separate per-check PRs.

> Consumer note (also in CHANGELOG): switches over `Severity` with a `default` branch will silently bucket INFO there until they add an explicit case — audit before surfacing INFO. Renderers should test `== SeverityInfo`, never `< SeverityOK`, because the zero value ("unset") also sits below OK.

## Testing

- `go build ./...`, `go test -count=1 ./...` (29 packages, 0 failures), `golangci-lint run` (0 issues)
- `go generate ./...` + `git diff --exit-code` — generated files unchanged